### PR TITLE
出題および解答をするためのページの作成

### DIFF
--- a/app/assets/javascripts/channels/exercise_activity.js
+++ b/app/assets/javascripts/channels/exercise_activity.js
@@ -1,22 +1,22 @@
 const testingCallback = data => {
   switch (data.status) {
-  case 'testing':
-    window.loader.show('解答をテストしています... 🤔')
-    break
-  case 'fail':
-    window.loader.fail('テストを実行できませんでした 😱')
-    break
-  case 'done':
-    window.loader.done('テストが完了しました 😆')
-    setTimeout(() => {
-      window.loader.hide()
-    }, 1000)
-    break
+    case 'testing':
+      window.loader.show('解答をテストしています... 🤔')
+      break
+    case 'fail':
+      window.loader.fail('テストを実行できませんでした 😱')
+      break
+    case 'done':
+      window.loader.done('テストが完了しました 😆')
+      setTimeout(() => {
+        window.loader.hide()
+      }, 1000)
+      break
   }
 }
 
 const exerciseOptions = {
-  channel: 'ExerciseActivityChannel',
+  channel: 'ExerciseActivityChannel'
   //room: 'repo'
 }
 

--- a/app/assets/javascripts/channels/exercise_activity.js
+++ b/app/assets/javascripts/channels/exercise_activity.js
@@ -1,0 +1,32 @@
+const testingCallback = data => {
+  switch (data.status) {
+  case 'testing':
+    window.loader.show('解答をテストしています... 🤔')
+    break
+  case 'fail':
+    window.loader.fail('テストを実行できませんでした 😱')
+    break
+  case 'done':
+    window.loader.done('テストが完了しました 😆')
+    setTimeout(() => {
+      window.loader.hide()
+    }, 1000)
+    break
+  }
+}
+
+const exerciseOptions = {
+  channel: 'ExerciseActivityChannel',
+  //room: 'repo'
+}
+
+window.exerciseActivity = () => {
+  window.App = window.App || {}
+  window.App.cable = ActionCable.createConsumer()
+
+  window.App.repoStream = window.App.cable.subscriptions.create(exerciseOptions, {
+    received(data) {
+      testingCallback(data)
+    }
+  })
+}

--- a/app/assets/javascripts/channels/exercise_activity.js
+++ b/app/assets/javascripts/channels/exercise_activity.js
@@ -3,9 +3,20 @@ const testingCallback = data => {
     case 'testing':
       window.loader.show('解答をテストしています... 🤔')
       break
+    case 'compile error':
+      window.loader.fail('コンパイルに失敗しました 😱')
+      setTimeout(() => {
+        window.loader.hide()
+        window.location.reload()
+      }, 2000)
+      break
     case 'fail':
       window.loader.fail('テストを実行できませんでした 😱')
       break
+      setTimeout(() => {
+        window.loader.hide()
+        window.location.reload()
+      }, 2000)
     case 'done':
       window.loader.done('テストが完了しました 😆')
       setTimeout(() => {

--- a/app/assets/javascripts/channels/exercise_activity.js
+++ b/app/assets/javascripts/channels/exercise_activity.js
@@ -10,6 +10,7 @@ const testingCallback = data => {
       window.loader.done('テストが完了しました 😆')
       setTimeout(() => {
         window.loader.hide()
+        window.location.reload()
       }, 1000)
       break
   }

--- a/app/channels/application_cable/connection.rb
+++ b/app/channels/application_cable/connection.rb
@@ -9,9 +9,10 @@ module ApplicationCable
     end
 
     protected
+
     def find_verified_user
       User.find(session['warden.user.user.key'][0][0])
-    rescue
+    rescue ActiveRecord::RecordNotFound
       reject_unauthorized_connection
     end
 

--- a/app/channels/application_cable/connection.rb
+++ b/app/channels/application_cable/connection.rb
@@ -2,5 +2,21 @@
 
 module ApplicationCable
   class Connection < ActionCable::Connection::Base
+    identified_by :current_user
+
+    def connect
+      self.current_user = find_verified_user
+    end
+
+    protected
+    def find_verified_user
+      User.find(session['warden.user.user.key'][0][0])
+    rescue
+      reject_unauthorized_connection
+    end
+
+    def session
+      @user_session ||= cookies.encrypted[Rails.application.config.session_options[:key]]
+    end
   end
 end

--- a/app/channels/application_cable/connection.rb
+++ b/app/channels/application_cable/connection.rb
@@ -11,12 +11,12 @@ module ApplicationCable
     protected
 
     def find_verified_user
-      User.find(session['warden.user.user.key'][0][0])
+      User.find(user_session['warden.user.user.key'][0][0])
     rescue ActiveRecord::RecordNotFound
       reject_unauthorized_connection
     end
 
-    def session
+    def user_session
       @user_session ||= cookies.encrypted[Rails.application.config.session_options[:key]]
     end
   end

--- a/app/channels/exercise_activity_channel.rb
+++ b/app/channels/exercise_activity_channel.rb
@@ -2,7 +2,7 @@
 
 class ExerciseActivityChannel < ApplicationCable::Channel
   def subscribed
-    # stream_from "some_channel"
+    stream_for current_user
   end
 
   def unsubscribed

--- a/app/channels/exercise_activity_channel.rb
+++ b/app/channels/exercise_activity_channel.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class ExerciseActivityChannel < ApplicationCable::Channel
+  def subscribed
+    # stream_from "some_channel"
+  end
+
+  def unsubscribed
+    # Any cleanup needed when channel is unsubscribed
+  end
+end

--- a/app/controllers/api/submissions_controller.rb
+++ b/app/controllers/api/submissions_controller.rb
@@ -24,10 +24,9 @@ class Api::SubmissionsController < ApplicationController
     end
 
     @submit.save
-    logger.debug @submit.inspect
-    logger.debug @s_q.inspect
-    logger.debug @code.inspect
 
+    QuestionTestWorker.perform_async(@submit.id, @submit.mission_id, @question.id)
+    ExerciseActivityChannel.broadcast_to current_user, status: 'testing'
     # create testing job
     render json: {}
   end

--- a/app/controllers/api/submissions_controller.rb
+++ b/app/controllers/api/submissions_controller.rb
@@ -56,6 +56,6 @@ class Api::SubmissionsController < ApplicationController
   end
 
   def set_question
-    @question ||= Question.find(params.require(:id))
+    @question = Question.find(params.require(:id))
   end
 end

--- a/app/controllers/api/submissions_controller.rb
+++ b/app/controllers/api/submissions_controller.rb
@@ -4,33 +4,36 @@ class Api::SubmissionsController < ApplicationController
   before_action :set_question, only: %i[question]
 
   def question
-    logger.debug params[:file_name]
-    logger.debug params[:code]
-
     @submit = Submit.new(submit_params)
-    logger.debug @submit.inspect
-    @s_b = @submit.build_submit_question({
-                                         submit_id: @submit.id,
-                                         question_id: @question.id
-                                       })
-    logger.debug @s_b.inspect
+
+    @s_q = @submit.build_submit_question(
+      submit_id: @submit.id,
+      question_id: @question.id
+    )
+
     pierced_locations = PiercedLocation.where(mission_id: @question.problem.mission)
+    @code = []
     Hash[params[:code].permit!].sort.to_h.each do |key, value|
       pierced_location = pierced_locations.find { |pl| pl.location_id == key.to_i }
-      code = @submit.submit_codes.build({
-                                  submit_id: @submit,
-                                  file_name: params[:file_name],
-                                  code: value,
-                                  pierced_location_id: pierced_location.id
-                                })
-      logger.debug code.inspect
+      @code << @submit.submit_codes.build(
+        submit_id: @submit.id,
+        file_name: params[:file_name],
+        code: value,
+        pierced_location_id: pierced_location.id
+      )
     end
+
+    @submit.save
+    logger.debug @submit.inspect
+    logger.debug @s_q.inspect
+    logger.debug @code.inspect
 
     # create testing job
     render json: {}
   end
 
   private
+
   def submit_params
     {
       user_id: current_user.id,

--- a/app/controllers/api/submissions_controller.rb
+++ b/app/controllers/api/submissions_controller.rb
@@ -1,8 +1,44 @@
 # frozen_string_literal: true
 
 class Api::SubmissionsController < ApplicationController
+  before_action :set_question, only: %i[question]
+
   def question
-    logger.debug(current_user.id)
+    logger.debug params[:file_name]
+    logger.debug params[:code]
+
+    @submit = Submit.new(submit_params)
+    logger.debug @submit.inspect
+    @s_b = @submit.build_submit_question({
+                                         submit_id: @submit.id,
+                                         question_id: @question.id
+                                       })
+    logger.debug @s_b.inspect
+    pierced_locations = PiercedLocation.where(mission_id: @question.problem.mission)
+    Hash[params[:code].permit!].sort.to_h.each do |key, value|
+      pierced_location = pierced_locations.find { |pl| pl.location_id == key.to_i }
+      code = @submit.submit_codes.build({
+                                  submit_id: @submit,
+                                  file_name: params[:file_name],
+                                  code: value,
+                                  pierced_location_id: pierced_location.id
+                                })
+      logger.debug code.inspect
+    end
+
+    # create testing job
     render json: {}
+  end
+
+  private
+  def submit_params
+    {
+      user_id: current_user.id,
+      mission_id: @question.problem.mission.id
+    }
+  end
+
+  def set_question
+    @question ||= Question.find(params.require(:id))
   end
 end

--- a/app/controllers/api/submissions_controller.rb
+++ b/app/controllers/api/submissions_controller.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+class Api::SubmissionsController < Api::ApplicationController
+end

--- a/app/controllers/api/submissions_controller.rb
+++ b/app/controllers/api/submissions_controller.rb
@@ -1,9 +1,8 @@
 # frozen_string_literal: true
 
-class Api::SubmissionsController < Api::ApplicationController
+class Api::SubmissionsController < ApplicationController
   def question
-    print params
-
-    render json: params
+    logger.debug(current_user.id)
+    render json: {}
   end
 end

--- a/app/controllers/api/submissions_controller.rb
+++ b/app/controllers/api/submissions_controller.rb
@@ -5,39 +5,54 @@ class Api::SubmissionsController < ApplicationController
 
   def question
     @submit = Submit.new(submit_params)
-
-    @s_q = @submit.build_submit_question(
-      submit_id: @submit.id,
-      question_id: @question.id
-    )
-
-    pierced_locations = PiercedLocation.where(mission_id: @question.problem.mission)
-    @code = []
-    Hash[params[:code].permit!].sort.to_h.each do |key, value|
-      pierced_location = pierced_locations.find { |pl| pl.location_id == key.to_i }
-      @code << @submit.submit_codes.build(
-        submit_id: @submit.id,
-        file_name: params[:file_name],
-        code: value,
-        pierced_location_id: pierced_location.id
-      )
-    end
-
+    @s_q = @submit.build_submit_question(submit_question_params)
+    @code = new_submit_codes
     @submit.save
 
-    QuestionTestWorker.perform_async(@submit.id, @submit.mission_id, @question.id)
-    ExerciseActivityChannel.broadcast_to current_user, status: 'testing'
-    # create testing job
-    render json: {}
+    exec_testing_job
+    render status: 200, json: { status: 'success' }
   end
 
   private
+
+  def exec_testing_job
+    QuestionTestWorker.perform_async(@submit.id, @submit.mission_id, @question.id)
+    ExerciseActivityChannel.broadcast_to current_user, status: 'testing'
+  end
+
+  def new_submit_codes
+    pierced_locations = PiercedLocation.where(mission_id: @question.problem.mission)
+    code = code_param.map do |key, value|
+      pierced_location = pierced_locations.find { |pl| pl.location_id == key.to_i }
+      @submit.submit_codes.build(submit_codes_params(value, pierced_location))
+    end
+    code
+  end
 
   def submit_params
     {
       user_id: current_user.id,
       mission_id: @question.problem.mission.id
     }
+  end
+
+  def submit_question_params
+    {
+      submit_id: @submit.id,
+      question_id: @question.id
+    }
+  end
+
+  def submit_codes_params(code, pierced_location)
+    params.permit(:file_name).merge(
+      submit_id: @submit.id,
+      code: code,
+      pierced_location_id: pierced_location.id
+    )
+  end
+
+  def code_param
+    Hash[params[:code].permit!].sort.to_h
   end
 
   def set_question

--- a/app/controllers/api/submissions_controller.rb
+++ b/app/controllers/api/submissions_controller.rb
@@ -1,4 +1,9 @@
 # frozen_string_literal: true
 
 class Api::SubmissionsController < Api::ApplicationController
+  def question
+    print params
+
+    render json: params
+  end
 end

--- a/app/controllers/exercises_controller.rb
+++ b/app/controllers/exercises_controller.rb
@@ -1,4 +1,25 @@
 # frozen_string_literal: true
 
 class ExercisesController < ApplicationController
+  before_action :authenticate_user!, only: :show
+  before_action :set_session, only: :show
+  before_action :set_mission, only: :show
+
+  def show
+    problems = @mission.problems
+    @problems_questions = {}
+    problems.each do |p|
+      @problems_questions[p] = p.questions
+    end
+  end
+
+  private
+
+  def set_mission
+    @mission = @session.missions.find(params[:mission_id])
+  end
+
+  def set_session
+    @session = Session.find(params[:session_id])
+  end
 end

--- a/app/controllers/exercises_controller.rb
+++ b/app/controllers/exercises_controller.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+class ExercisesController < ApplicationController
+end

--- a/app/controllers/exercises_controller.rb
+++ b/app/controllers/exercises_controller.rb
@@ -10,6 +10,7 @@ class ExercisesController < ApplicationController
     @questions = Question.of_problem(@problems).order(:name)
     @problems_with_tests = Problem.search_tests_with_problem_id(@problems)
     @questions_with_tests = Question.search_tests_with_problem_id(@problems)
+    @java_pierced_contents = @mission.java_pierced_contents
   end
 
   private

--- a/app/controllers/exercises_controller.rb
+++ b/app/controllers/exercises_controller.rb
@@ -12,7 +12,7 @@ class ExercisesController < ApplicationController
     # Problem.search_tests_with_problem_id(@problems)
     @questions_with_tests = PiercedLocation.of_question_with_test_info(@questions)
     # Question.search_tests_with_problem_id(@problems)
-    @score = {question: Question.calc_score(current_user.id, @questions)}
+    @score = { question: Question.calc_score(current_user.id, @questions) }
     @java_pierced_contents = @mission.java_pierced_contents
   end
 

--- a/app/controllers/exercises_controller.rb
+++ b/app/controllers/exercises_controller.rb
@@ -13,7 +13,7 @@ class ExercisesController < ApplicationController
     @questions_with_tests = PiercedLocation.of_question_with_test_info(@questions)
     # Question.search_tests_with_problem_id(@problems)
     @score = { question: Question.calc_score(current_user.id, @questions) }
-    @java_pierced_contents = @mission.java_pierced_contents
+    @java_pierced_contents = @mission.java_problem_contents(current_user.id)
   end
 
   private

--- a/app/controllers/exercises_controller.rb
+++ b/app/controllers/exercises_controller.rb
@@ -12,6 +12,7 @@ class ExercisesController < ApplicationController
     # Problem.search_tests_with_problem_id(@problems)
     @questions_with_tests = PiercedLocation.of_question_with_test_info(@questions)
     # Question.search_tests_with_problem_id(@problems)
+    @score = {question: Question.calc_score(current_user.id, @questions)}
     @java_pierced_contents = @mission.java_pierced_contents
   end
 

--- a/app/controllers/exercises_controller.rb
+++ b/app/controllers/exercises_controller.rb
@@ -8,7 +8,8 @@ class ExercisesController < ApplicationController
   def show
     @problems = @mission.problems.order(:name)
     @questions = Question.of_problem(@problems).order(:name)
-    @problems_with_tests = Problem.search_tests_with_problem_id(@problems)
+    @problems_with_tests = PiercedLocation.of_problem_with_test_info(@problems)
+    # Problem.search_tests_with_problem_id(@problems)
     @questions_with_tests = Question.search_tests_with_problem_id(@problems)
     @java_pierced_contents = @mission.java_pierced_contents
   end

--- a/app/controllers/exercises_controller.rb
+++ b/app/controllers/exercises_controller.rb
@@ -6,10 +6,10 @@ class ExercisesController < ApplicationController
   before_action :set_mission, only: :show
 
   def show
-    problems = @mission.problems
-    @problems_and_questions = Problem.search_questions_with_problem_id(problems)
-    @problems_with_tests = Problem.search_tests_with_problem_id(problems)
-    @questions_with_tests = Question.search_tests_with_problem_id(problems)
+    @problems = @mission.problems.order(:name)
+    @questions = Question.of_problem(@problems).order(:name)
+    @problems_with_tests = Problem.search_tests_with_problem_id(@problems)
+    @questions_with_tests = Question.search_tests_with_problem_id(@problems)
   end
 
   private

--- a/app/controllers/exercises_controller.rb
+++ b/app/controllers/exercises_controller.rb
@@ -10,7 +10,8 @@ class ExercisesController < ApplicationController
     @questions = Question.of_problem(@problems).order(:name)
     @problems_with_tests = PiercedLocation.of_problem_with_test_info(@problems)
     # Problem.search_tests_with_problem_id(@problems)
-    @questions_with_tests = Question.search_tests_with_problem_id(@problems)
+    @questions_with_tests = PiercedLocation.of_question_with_test_info(@questions)
+    # Question.search_tests_with_problem_id(@problems)
     @java_pierced_contents = @mission.java_pierced_contents
   end
 

--- a/app/controllers/exercises_controller.rb
+++ b/app/controllers/exercises_controller.rb
@@ -8,10 +8,8 @@ class ExercisesController < ApplicationController
   def show
     @problems_questions = {}
     problems = @mission.problems
-    @problems_and_tests = Problem.search_test_with_problem_id(problems)
-    problems.each do |p|
-      @problems_questions[p] = p.questions
-    end
+    @problems_with_tests = Problem.search_tests_with_problem_id(problems)
+    @problems_and_questions = Problem.search_questions_with_problem_id(problems)
   end
 
   private

--- a/app/controllers/exercises_controller.rb
+++ b/app/controllers/exercises_controller.rb
@@ -6,10 +6,10 @@ class ExercisesController < ApplicationController
   before_action :set_mission, only: :show
 
   def show
-    @problems_questions = {}
     problems = @mission.problems
-    @problems_with_tests = Problem.search_tests_with_problem_id(problems)
     @problems_and_questions = Problem.search_questions_with_problem_id(problems)
+    @problems_with_tests = Problem.search_tests_with_problem_id(problems)
+    @questions_with_tests = Question.search_tests_with_problem_id(problems)
   end
 
   private

--- a/app/controllers/exercises_controller.rb
+++ b/app/controllers/exercises_controller.rb
@@ -6,8 +6,9 @@ class ExercisesController < ApplicationController
   before_action :set_mission, only: :show
 
   def show
-    problems = @mission.problems
     @problems_questions = {}
+    problems = @mission.problems
+    @problems_and_tests = Problem.search_test_with_problem_id(problems)
     problems.each do |p|
       @problems_questions[p] = p.questions
     end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+class SessionsController < ApplicationController
+end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,4 +1,20 @@
 # frozen_string_literal: true
 
 class SessionsController < ApplicationController
+  before_action :authenticate_user!, only: :show
+  before_action :set_session, only: :show
+
+  def show
+    missions = @session.missions
+    @missions_problems = {}
+    missions.each do |m|
+      @missions_problems[m] = m.problems
+    end
+  end
+
+  private
+
+  def set_session
+    @session = Session.find(params[:id] || params[:session_id])
+  end
 end

--- a/app/javascript/actions/exercise/index.js
+++ b/app/javascript/actions/exercise/index.js
@@ -1,0 +1,3 @@
+const { createAction } = require('redux-act')
+
+export const initializeProblemAndQuestionData = createAction('initialize problem and question data')

--- a/app/javascript/components/exercise/CodeBlock.js
+++ b/app/javascript/components/exercise/CodeBlock.js
@@ -29,8 +29,19 @@ class CodeBlock extends React.Component {
       .post(
         '/api/submissions/question',
         {
+          /*
           file_name: this.props.file,
           code: this.state.code
+          */
+          "id": 6,
+	        "file_name": "/src/main/java/sequence/NumSequenceGenerator.java",
+	        "code":
+	        {
+		        1: "NumData[] seq = new NumData[size];\n        for (int i = 0; i < size; i++) {\n            seq[i] = new NumData(i);\n        }\n        return new NumDataSequence(seq);",
+		        2: "",
+		        3: "",
+		        4: "",
+	        }
         },
         {
           withCredentials: true

--- a/app/javascript/components/exercise/CodeBlock.js
+++ b/app/javascript/components/exercise/CodeBlock.js
@@ -26,12 +26,12 @@ class CodeBlock extends React.Component {
   render() {
     return (
       <div>
-        <div className='columns'>
-          <div className='column is-11'>
+        <div className="columns">
+          <div className="column is-11">
             <h2>ファイル名: {this.props.file}</h2>
           </div>
-          <div className='column is-11'>
-            <button type="button" className="button is-primary" onClick={this.handleSubmit} >
+          <div className="column is-11">
+            <button type="button" className="button is-primary" onClick={this.handleSubmit}>
               テスト
             </button>
           </div>

--- a/app/javascript/components/exercise/CodeBlock.js
+++ b/app/javascript/components/exercise/CodeBlock.js
@@ -2,6 +2,7 @@ import React from 'react'
 import { connect } from 'react-redux'
 
 import AceEditor from 'react-ace'
+import axios from 'axios'
 
 import 'ace-builds/src-noconflict/mode-java'
 import 'ace-builds/src-noconflict/theme-solarized_light'
@@ -12,15 +13,24 @@ class CodeBlock extends React.Component {
     this.state = {
       code: this.props.code
     }
+    //axios.defaults.headers['x-xsrf-token'] = document.querySelector('meta[name="csrf-token"]').getAttribute('content')
   }
 
   onChange = newValue => {
     this.setState({ code: newValue })
   }
 
-  handleSubmit = () => {
+  handleSubmit = async () => {
     //console.log('code', this.state.code)
     // request to backend for testing
+    const result = await axios
+      .post('/api/submissions/question', {
+        file_name: this.props.file,
+        code: this.state.code
+      })
+      .then(res => res.data)
+      .catch(/*e => console.log(e)*/)
+    //console.log(result)
   }
 
   render() {

--- a/app/javascript/components/exercise/CodeBlock.js
+++ b/app/javascript/components/exercise/CodeBlock.js
@@ -22,25 +22,42 @@ class CodeBlock extends React.Component {
     this.setState({ code: newValue })
   }
 
+  createRequestCode = code => {
+    let data = {}
+    let flag = false
+    let location = -1
+
+    code.split('\n').forEach((line, index) => {
+      const end = line.match(/\s*(\/\/ !\])/)
+      if (end) {
+        flag = false
+        location = -1
+        return
+      }
+
+      const start = line.match(/\s*(\/\/ !\[)(\d+)/)
+      if (start) {
+        flag = true
+        location = start[2]
+        data[location] = ''
+        return
+      }
+
+      if (flag) {
+        data[location] += '\n' + line
+      }
+    })
+    return data
+  }
+
   handleSubmit = async () => {
-    //console.log('code', this.state.code)
-    // request to backend for testing
     const result = await axios
       .post(
         '/api/submissions/question',
         {
-          /*
+          id: this.props.id,
           file_name: this.props.file,
-          code: this.state.code
-          */
-          id: 6,
-          file_name: '/src/main/java/sequence/NumSequenceGenerator.java',
-          code: {
-            1: '        NumData[] seq = new NumData[size];\n        for (int i = 0; i < size; i++) {\n            seq[i] = new NumData(i);\n        }\n        return new NumDataSequence(seq);',
-            2: '        NumData[] seq = new NumData[size];\n        for (int i = 0; i < size; i++) {\n            seq[i] = new NumData(i);\n        }\n        return new NumDataSequence(seq);',
-            3: '        NumData[] seq = new NumData[size];\n        for (int i = 0; i < size; i++) {\n            seq[i] = new NumData(i);\n        }\n        return new NumDataSequence(seq);',
-            4: '        NumData[] seq = new NumData[size];\n        for (int i = 0; i < size; i++) {\n            seq[i] = new NumData(i);\n        }\n        return new NumDataSequence(seq);'
-          }
+          code: this.createRequestCode(this.state.code)
         },
         {
           withCredentials: true

--- a/app/javascript/components/exercise/CodeBlock.js
+++ b/app/javascript/components/exercise/CodeBlock.js
@@ -33,15 +33,14 @@ class CodeBlock extends React.Component {
           file_name: this.props.file,
           code: this.state.code
           */
-          "id": 6,
-	        "file_name": "/src/main/java/sequence/NumSequenceGenerator.java",
-	        "code":
-	        {
-		        1: "        NumData[] seq = new NumData[size];\n        for (int i = 0; i < size; i++) {\n            seq[i] = new NumData(i);\n        }\n        return new NumDataSequence(seq);",
-		        2: "",
-		        3: "",
-		        4: "",
-	        }
+          id: 6,
+          file_name: '/src/main/java/sequence/NumSequenceGenerator.java',
+          code: {
+            1: '        NumData[] seq = new NumData[size];\n        for (int i = 0; i < size; i++) {\n            seq[i] = new NumData(i);\n        }\n        return new NumDataSequence(seq);',
+            2: '        NumData[] seq = new NumData[size];\n        for (int i = 0; i < size; i++) {\n            seq[i] = new NumData(i);\n        }\n        return new NumDataSequence(seq);',
+            3: '        NumData[] seq = new NumData[size];\n        for (int i = 0; i < size; i++) {\n            seq[i] = new NumData(i);\n        }\n        return new NumDataSequence(seq);',
+            4: '        NumData[] seq = new NumData[size];\n        for (int i = 0; i < size; i++) {\n            seq[i] = new NumData(i);\n        }\n        return new NumDataSequence(seq);'
+          }
         },
         {
           withCredentials: true

--- a/app/javascript/components/exercise/CodeBlock.js
+++ b/app/javascript/components/exercise/CodeBlock.js
@@ -37,7 +37,7 @@ class CodeBlock extends React.Component {
 	        "file_name": "/src/main/java/sequence/NumSequenceGenerator.java",
 	        "code":
 	        {
-		        1: "NumData[] seq = new NumData[size];\n        for (int i = 0; i < size; i++) {\n            seq[i] = new NumData(i);\n        }\n        return new NumDataSequence(seq);",
+		        1: "        NumData[] seq = new NumData[size];\n        for (int i = 0; i < size; i++) {\n            seq[i] = new NumData(i);\n        }\n        return new NumDataSequence(seq);",
 		        2: "",
 		        3: "",
 		        4: "",

--- a/app/javascript/components/exercise/CodeBlock.js
+++ b/app/javascript/components/exercise/CodeBlock.js
@@ -18,10 +18,24 @@ class CodeBlock extends React.Component {
     this.setState({ code: newValue })
   }
 
+  handleSubmit = () => {
+    //console.log('code', this.state.code)
+    // request to backend for testing
+  }
+
   render() {
     return (
       <div>
-        <h2>ファイル名: {this.props.file}</h2>
+        <div className='columns'>
+          <div className='column is-11'>
+            <h2>ファイル名: {this.props.file}</h2>
+          </div>
+          <div className='column is-11'>
+            <button type="button" className="button is-primary" onClick={this.handleSubmit} >
+              テスト
+            </button>
+          </div>
+        </div>
         <AceEditor
           mode="java"
           theme="solarized_light"

--- a/app/javascript/components/exercise/CodeBlock.js
+++ b/app/javascript/components/exercise/CodeBlock.js
@@ -1,0 +1,42 @@
+import React from 'react'
+import { connect } from 'react-redux'
+
+import AceEditor from 'react-ace'
+
+import 'ace-builds/src-noconflict/mode-java'
+import 'ace-builds/src-noconflict/theme-solarized_light'
+
+class CodeBlock extends React.Component {
+  constructor(props) {
+    super(props)
+    this.state = {
+      code: this.props.code
+    }
+  }
+
+  onChange = newValue => {
+    this.setState({ code: newValue })
+  }
+
+  render() {
+    return (
+      <div>
+        <h2>ファイル名: {this.props.file}</h2>
+        <AceEditor
+          mode="java"
+          theme="solarized_light"
+          onChange={this.onChange}
+          name="code"
+          value={this.state.code}
+          width="auto"
+          editorProps={{ $blockScrolling: true }}
+        />
+      </div>
+    )
+  }
+}
+
+export default connect(
+  state => ({}),
+  {}
+)(CodeBlock)

--- a/app/javascript/components/exercise/CodeBlock.js
+++ b/app/javascript/components/exercise/CodeBlock.js
@@ -95,7 +95,4 @@ class CodeBlock extends React.Component {
   }
 }
 
-export default connect(
-  state => ({}),
-  {}
-)(CodeBlock)
+export default connect()(CodeBlock)

--- a/app/javascript/components/exercise/CodeBlock.js
+++ b/app/javascript/components/exercise/CodeBlock.js
@@ -13,7 +13,9 @@ class CodeBlock extends React.Component {
     this.state = {
       code: this.props.code
     }
-    //axios.defaults.headers['x-xsrf-token'] = document.querySelector('meta[name="csrf-token"]').getAttribute('content')
+    axios.defaults.headers['x-csrf-token'] = document
+      .querySelector('meta[name="csrf-token"]')
+      .getAttribute('content')
   }
 
   onChange = newValue => {
@@ -24,10 +26,16 @@ class CodeBlock extends React.Component {
     //console.log('code', this.state.code)
     // request to backend for testing
     const result = await axios
-      .post('/api/submissions/question', {
-        file_name: this.props.file,
-        code: this.state.code
-      })
+      .post(
+        '/api/submissions/question',
+        {
+          file_name: this.props.file,
+          code: this.state.code
+        },
+        {
+          withCredentials: true
+        }
+      )
       .then(res => res.data)
       .catch(/*e => console.log(e)*/)
     //console.log(result)

--- a/app/javascript/components/exercise/CodeBlock.js
+++ b/app/javascript/components/exercise/CodeBlock.js
@@ -58,7 +58,7 @@ class CodeBlock extends React.Component {
           <div className="column is-11">
             <h2>ファイル名: {this.props.file}</h2>
           </div>
-          <div className="column is-11">
+          <div className="column is-1">
             <button type="button" className="button is-primary" onClick={this.handleSubmit}>
               テスト
             </button>

--- a/app/javascript/components/exercise/ProblemCode.js
+++ b/app/javascript/components/exercise/ProblemCode.js
@@ -6,15 +6,15 @@ class ProblemCode extends React.Component {
     super(props)
   }
 
-  renderCode = (javaFiles) => {
+  renderCode = javaFiles => {
     const files = javaFiles.filter((f, i, arr) => arr.indexOf(f) === i)
     let code = []
     files.forEach((file, i) => {
       const content = this.props.javaPiercedContents.find(content => {
-        return (Object.keys(content)[0] === file)
+        return Object.keys(content)[0] === file
       })
       code.push(
-        <div key={i} style={{marginTop:30}}>
+        <div key={i} style={{ marginTop: 30 }}>
           <h2>ファイル名: {file}</h2>
           <pre>{content[file]}</pre>
         </div>
@@ -24,12 +24,10 @@ class ProblemCode extends React.Component {
   }
 
   render() {
-    const files = this.props.problemWithTests.filter(p => p.problem_id === this.props.problemID).map(p => p.file_name)
-    return (
-      <div>
-        {this.renderCode(files)}
-      </div>
-    )
+    const files = this.props.problemWithTests
+      .filter(p => p.problem_id === this.props.problemID)
+      .map(p => p.file_name)
+    return <div>{this.renderCode(files)}</div>
   }
 }
 

--- a/app/javascript/components/exercise/ProblemCode.js
+++ b/app/javascript/components/exercise/ProblemCode.js
@@ -1,6 +1,8 @@
 import React from 'react'
 import { connect } from 'react-redux'
 
+import CodeBlock from './CodeBlock'
+
 class ProblemCode extends React.Component {
   constructor(props) {
     super(props)
@@ -15,8 +17,7 @@ class ProblemCode extends React.Component {
       })
       code.push(
         <div key={i} style={{ marginTop: 30 }}>
-          <h2>ファイル名: {file}</h2>
-          <pre>{content[file]}</pre>
+          <CodeBlock file={file} code={content[file]} />
         </div>
       )
     })

--- a/app/javascript/components/exercise/ProblemCode.js
+++ b/app/javascript/components/exercise/ProblemCode.js
@@ -1,0 +1,42 @@
+import React from 'react'
+import { connect } from 'react-redux'
+
+class ProblemCode extends React.Component {
+  constructor(props) {
+    super(props)
+  }
+
+  renderCode = (javaFiles) => {
+    const files = javaFiles.filter((f, i, arr) => arr.indexOf(f) === i)
+    let code = []
+    files.forEach((file, i) => {
+      const content = this.props.javaPiercedContents.find(content => {
+        return (Object.keys(content)[0] === file)
+      })
+      code.push(
+        <div key={i} style={{marginTop:30}}>
+          <h2>ファイル名: {file}</h2>
+          <pre>{content[file]}</pre>
+        </div>
+      )
+    })
+    return code
+  }
+
+  render() {
+    const files = this.props.problemWithTests.filter(p => p.problem_id === this.props.problemID).map(p => p.file_name)
+    return (
+      <div>
+        {this.renderCode(files)}
+      </div>
+    )
+  }
+}
+
+export default connect(
+  state => ({
+    javaPiercedContents: state.problems.meta.javaPiercedContents,
+    problemWithTests: state.problems.meta.problemsWithTests
+  }),
+  {}
+)(ProblemCode)

--- a/app/javascript/components/exercise/ProblemContents.js
+++ b/app/javascript/components/exercise/ProblemContents.js
@@ -6,6 +6,7 @@ import QuestionContents from './QuestionContents'
 
 const Problem = styled.div`
   margin-top: 30px;
+  margin-bottom: 30px;
 `
 
 export default function ProblemContents({ contents }) {

--- a/app/javascript/components/exercise/ProblemContents.js
+++ b/app/javascript/components/exercise/ProblemContents.js
@@ -1,14 +1,24 @@
 import React from 'react'
+import styled from 'styled-components'
+
+import QuestionContents from './QuestionContents'
+
+const Problem = styled.div`
+  margin-top: 30px;
+`
 
 export default function ProblemContents({ contents }) {
   return (
-    <div>
-      <div>
-        <h1>{contents.name}</h1>
-      </div>
+    <Problem>
+      <h1>{contents.name}</h1>
       <div>
         <p>{contents.detail}</p>
       </div>
-    </div>
+      <div className="questions">
+        {contents.questionList.map((q, i) => {
+          return <QuestionContents key={i} contents={q} />
+        })}
+      </div>
+    </Problem>
   )
 }

--- a/app/javascript/components/exercise/ProblemContents.js
+++ b/app/javascript/components/exercise/ProblemContents.js
@@ -13,7 +13,7 @@ export default function ProblemContents({ contents }) {
   return (
     <Problem>
       <h1>大問 {contents.name}</h1>
-      <div style={{margin:'20px', whiteSpace: 'pre-line'}}>
+      <div style={{ margin: '20px', whiteSpace: 'pre-line' }}>
         <p>{contents.detail}</p>
       </div>
       <ProblemCode problemID={contents.id} />

--- a/app/javascript/components/exercise/ProblemContents.js
+++ b/app/javascript/components/exercise/ProblemContents.js
@@ -1,0 +1,15 @@
+import React from 'react'
+
+export default function ProblemContents({ contents }) {
+  console.log(contents)
+  return (
+    <div>
+      <div>
+        <h1>{contents.name}</h1>
+      </div>
+      <div>
+        <p>{contents.detail}</p>
+      </div>
+    </div>
+  )
+}

--- a/app/javascript/components/exercise/ProblemContents.js
+++ b/app/javascript/components/exercise/ProblemContents.js
@@ -1,6 +1,7 @@
 import React from 'react'
 import styled from 'styled-components'
 
+import ProblemCode from './ProblemCode'
 import QuestionContents from './QuestionContents'
 
 const Problem = styled.div`
@@ -14,6 +15,7 @@ export default function ProblemContents({ contents }) {
       <div>
         <p>{contents.detail}</p>
       </div>
+      <ProblemCode problemID={contents.id} />
       <div className="questions">
         {contents.questionList.map((q, i) => {
           return <QuestionContents key={i} contents={q} />

--- a/app/javascript/components/exercise/ProblemContents.js
+++ b/app/javascript/components/exercise/ProblemContents.js
@@ -1,7 +1,6 @@
 import React from 'react'
 
 export default function ProblemContents({ contents }) {
-  console.log(contents)
   return (
     <div>
       <div>

--- a/app/javascript/components/exercise/ProblemContents.js
+++ b/app/javascript/components/exercise/ProblemContents.js
@@ -12,8 +12,8 @@ const Problem = styled.div`
 export default function ProblemContents({ contents }) {
   return (
     <Problem>
-      <h1>{contents.name}</h1>
-      <div>
+      <h1>大問 {contents.name}</h1>
+      <div style={{margin:'20px', whiteSpace: 'pre-line'}}>
         <p>{contents.detail}</p>
       </div>
       <ProblemCode problemID={contents.id} />

--- a/app/javascript/components/exercise/QuestionCode.js
+++ b/app/javascript/components/exercise/QuestionCode.js
@@ -17,7 +17,7 @@ class QuestionCode extends React.Component {
       })
       code.push(
         <div key={i} style={{ marginTop: 30 }}>
-          <CodeBlock file={file} code={content[file]} />
+          <CodeBlock id={this.props.questionID} file={file} code={content[file]} />
         </div>
       )
     })

--- a/app/javascript/components/exercise/QuestionCode.js
+++ b/app/javascript/components/exercise/QuestionCode.js
@@ -1,6 +1,8 @@
 import React from 'react'
 import { connect } from 'react-redux'
 
+import CodeBlock from './CodeBlock'
+
 class QuestionCode extends React.Component {
   constructor(props) {
     super(props)
@@ -15,8 +17,7 @@ class QuestionCode extends React.Component {
       })
       code.push(
         <div key={i} style={{ marginTop: 30 }}>
-          <h2>ファイル名: {file}</h2>
-          <pre>{content[file]}</pre>
+          <CodeBlock file={file} code={content[file]} />
         </div>
       )
     })

--- a/app/javascript/components/exercise/QuestionCode.js
+++ b/app/javascript/components/exercise/QuestionCode.js
@@ -1,0 +1,40 @@
+import React from 'react'
+import { connect } from 'react-redux'
+
+class QuestionCode extends React.Component {
+  constructor(props) {
+    super(props)
+  }
+
+  renderCode = javaFiles => {
+    const files = javaFiles.filter((f, i, arr) => arr.indexOf(f) === i)
+    let code = []
+    files.forEach((file, i) => {
+      const content = this.props.javaPiercedContents.find(content => {
+        return Object.keys(content)[0] === file
+      })
+      code.push(
+        <div key={i} style={{ marginTop: 30 }}>
+          <h2>ファイル名: {file}</h2>
+          <pre>{content[file]}</pre>
+        </div>
+      )
+    })
+    return code
+  }
+
+  render() {
+    const files = this.props.questionsWithTests
+      .filter(q => q.question_id === this.props.questionID)
+      .map(q => q.file_name)
+    return <div>{this.renderCode(files)}</div>
+  }
+}
+
+export default connect(
+  state => ({
+    javaPiercedContents: state.problems.meta.javaPiercedContents,
+    questionsWithTests: state.problems.meta.questionsWithTests
+  }),
+  {}
+)(QuestionCode)

--- a/app/javascript/components/exercise/QuestionContents.js
+++ b/app/javascript/components/exercise/QuestionContents.js
@@ -10,8 +10,8 @@ const Question = styled.div`
 export default function QuestionContents({ contents }) {
   return (
     <Question>
-      <h2>{contents.name}</h2>
-      <div>
+      <h2>小問 {contents.name}</h2>
+      <div style={{margin:'20px', whiteSpace: 'pre-line'}}>
         <p>{contents.detail}</p>
       </div>
       <QuestionCode questionID={contents.id} />

--- a/app/javascript/components/exercise/QuestionContents.js
+++ b/app/javascript/components/exercise/QuestionContents.js
@@ -1,0 +1,17 @@
+import React from 'react'
+import styled from 'styled-components'
+
+const Question = styled.div`
+  margin-top: 30px;
+`
+
+export default function QuestionContents({ contents }) {
+  return (
+    <Question>
+      <h2>{contents.name}</h2>
+      <div>
+        <p>{contents.detail}</p>
+      </div>
+    </Question>
+  )
+}

--- a/app/javascript/components/exercise/QuestionContents.js
+++ b/app/javascript/components/exercise/QuestionContents.js
@@ -15,7 +15,9 @@ export default function QuestionContents({ contents }) {
           <h2>小問 {contents.name}</h2>
         </div>
         <div className="column is-2">
-          <p>{contents.currentScore} 点(現在) / {contents.perfectScore} 点(満点)</p>
+          <p>
+            {contents.currentScore} 点(現在) / {contents.perfectScore} 点(満点)
+          </p>
         </div>
       </div>
       <div style={{ margin: '20px', whiteSpace: 'pre-line' }}>

--- a/app/javascript/components/exercise/QuestionContents.js
+++ b/app/javascript/components/exercise/QuestionContents.js
@@ -10,7 +10,14 @@ const Question = styled.div`
 export default function QuestionContents({ contents }) {
   return (
     <Question>
-      <h2>小問 {contents.name}</h2>
+      <div className="columns">
+        <div className="column is-10">
+          <h2>小問 {contents.name}</h2>
+        </div>
+        <div className="column is-2">
+          <p>{contents.currentScore} 点(現在) / {contents.perfectScore} 点(満点)</p>
+        </div>
+      </div>
       <div style={{ margin: '20px', whiteSpace: 'pre-line' }}>
         <p>{contents.detail}</p>
       </div>

--- a/app/javascript/components/exercise/QuestionContents.js
+++ b/app/javascript/components/exercise/QuestionContents.js
@@ -4,6 +4,7 @@ import styled from 'styled-components'
 import QuestionCode from './QuestionCode'
 const Question = styled.div`
   margin-top: 30px;
+  margin-bottom: 30px;
 `
 
 export default function QuestionContents({ contents }) {

--- a/app/javascript/components/exercise/QuestionContents.js
+++ b/app/javascript/components/exercise/QuestionContents.js
@@ -1,6 +1,7 @@
 import React from 'react'
 import styled from 'styled-components'
 
+import QuestionCode from './QuestionCode'
 const Question = styled.div`
   margin-top: 30px;
 `
@@ -12,6 +13,7 @@ export default function QuestionContents({ contents }) {
       <div>
         <p>{contents.detail}</p>
       </div>
+      <QuestionCode questionID={contents.id} />
     </Question>
   )
 }

--- a/app/javascript/components/exercise/QuestionContents.js
+++ b/app/javascript/components/exercise/QuestionContents.js
@@ -11,7 +11,7 @@ export default function QuestionContents({ contents }) {
   return (
     <Question>
       <h2>小問 {contents.name}</h2>
-      <div style={{margin:'20px', whiteSpace: 'pre-line'}}>
+      <div style={{ margin: '20px', whiteSpace: 'pre-line' }}>
         <p>{contents.detail}</p>
       </div>
       <QuestionCode questionID={contents.id} />

--- a/app/javascript/components/exercise/TheExercise.js
+++ b/app/javascript/components/exercise/TheExercise.js
@@ -8,13 +8,16 @@ class TheExercise extends React.Component {
     const {
       problemData,
       questionData,
+      score,
       problemsWithTests,
       questionsWithTests,
       javaPiercedContents
     } = this.props
+    console.log(score)
     this.props.initializeProblemAndQuestionData({
       problemData,
       questionData,
+      score,
       problemsWithTests,
       questionsWithTests,
       javaPiercedContents

--- a/app/javascript/components/exercise/TheExercise.js
+++ b/app/javascript/components/exercise/TheExercise.js
@@ -1,11 +1,21 @@
 import React from 'react'
+import { connect } from 'react-redux'
+import { initializeProblemAndQuestionData } from '../../actions/exercise'
 
 class TheExercise extends React.Component {
   componentDidMount() {
     console.log(this.props)
+    const { problems, questions, problemsWithTests, questionsWithTests } = this.props
+    this.props.initializeProblemAndQuestionData({
+      problems,
+      questions,
+      problemsWithTests,
+      questionsWithTests
+    })
   }
 
   render() {
+    console.log("store", this.props)
     return (
       <div>
         <h1>The Exersice</h1>
@@ -14,4 +24,9 @@ class TheExercise extends React.Component {
   }
 }
 
-export default TheExercise
+export default connect(
+  state => ({}),
+  {
+    initializeProblemAndQuestionData
+  }
+)(TheExercise)

--- a/app/javascript/components/exercise/TheExercise.js
+++ b/app/javascript/components/exercise/TheExercise.js
@@ -5,12 +5,13 @@ import TheProblems from './TheProblems'
 
 class TheExercise extends React.Component {
   componentDidMount() {
-    const { problemData, questionData, problemsWithTests, questionsWithTests } = this.props
+    const { problemData, questionData, problemsWithTests, questionsWithTests, javaPiercedContents } = this.props
     this.props.initializeProblemAndQuestionData({
       problemData,
       questionData,
       problemsWithTests,
-      questionsWithTests
+      questionsWithTests,
+      javaPiercedContents
     })
   }
 

--- a/app/javascript/components/exercise/TheExercise.js
+++ b/app/javascript/components/exercise/TheExercise.js
@@ -1,0 +1,17 @@
+import React from 'react'
+
+class TheExercise extends React.Component {
+  componentDidMount() {
+    console.log(this.props)
+  }
+
+  render() {
+    return (
+      <div>
+        <h1>The Exersice</h1>
+      </div>
+    )
+  }
+}
+
+export default TheExercise

--- a/app/javascript/components/exercise/TheExercise.js
+++ b/app/javascript/components/exercise/TheExercise.js
@@ -1,31 +1,33 @@
 import React from 'react'
 import { connect } from 'react-redux'
 import { initializeProblemAndQuestionData } from '../../actions/exercise'
+import TheProblems from './TheProblems'
 
 class TheExercise extends React.Component {
   componentDidMount() {
-    console.log(this.props)
-    const { problems, questions, problemsWithTests, questionsWithTests } = this.props
+    const { problemData, questionData, problemsWithTests, questionsWithTests } = this.props
     this.props.initializeProblemAndQuestionData({
-      problems,
-      questions,
+      problemData,
+      questionData,
       problemsWithTests,
       questionsWithTests
     })
   }
 
   render() {
-    console.log("store", this.props)
     return (
       <div>
         <h1>The Exersice</h1>
+        <TheProblems problemList={this.props.problems.problemList} />
       </div>
     )
   }
 }
 
 export default connect(
-  state => ({}),
+  state => ({
+    problems: state.problems
+  }),
   {
     initializeProblemAndQuestionData
   }

--- a/app/javascript/components/exercise/TheExercise.js
+++ b/app/javascript/components/exercise/TheExercise.js
@@ -5,7 +5,13 @@ import TheProblems from './TheProblems'
 
 class TheExercise extends React.Component {
   componentDidMount() {
-    const { problemData, questionData, problemsWithTests, questionsWithTests, javaPiercedContents } = this.props
+    const {
+      problemData,
+      questionData,
+      problemsWithTests,
+      questionsWithTests,
+      javaPiercedContents
+    } = this.props
     this.props.initializeProblemAndQuestionData({
       problemData,
       questionData,

--- a/app/javascript/components/exercise/TheExercise.js
+++ b/app/javascript/components/exercise/TheExercise.js
@@ -13,7 +13,6 @@ class TheExercise extends React.Component {
       questionsWithTests,
       javaPiercedContents
     } = this.props
-    console.log(score)
     this.props.initializeProblemAndQuestionData({
       problemData,
       questionData,

--- a/app/javascript/components/exercise/TheProblems.js
+++ b/app/javascript/components/exercise/TheProblems.js
@@ -9,48 +9,45 @@ class TheProblems extends React.Component {
       visibleProblemIndex: 0
     }
   }
-  renderTabs = (visibleProblemIndex) => {
+  renderTabs = visibleProblemIndex => {
     return (
-      <div className='tabs'>
-        {
-          this.props.problemList.map((p, i) => (
-            this.renderTab(i, visibleProblemIndex)
-          ))
-        }
+      <div className="tabs">
+        {this.props.problemList.map((p, i) => this.renderTab(i, visibleProblemIndex))}
       </div>
     )
   }
 
   renderTab = (index, visibleProblemIndex) => {
-    if ( index === visibleProblemIndex) {
+    if (index === visibleProblemIndex) {
       return (
         <li
           className={index === visibleProblemIndex && 'is-active'}
           key={index}
-          onClick={() => {this.changeActiveTab(index)}}
-        >
-          <a>{`problem${index+1}`}</a>
+          onClick={() => {
+            this.changeActiveTab(index)
+          }}>
+          <a>{`problem${index + 1}`}</a>
         </li>
       )
     }
     return (
       <li
         key={index}
-        onClick={() => {this.changeActiveTab(index)}}
-      >
-        <a>{`problem${index+1}`}</a>
+        onClick={() => {
+          this.changeActiveTab(index)
+        }}>
+        <a>{`problem${index + 1}`}</a>
       </li>
-
     )
   }
 
-  changeActiveTab = (index) => {
-    this.setState({visibleProblemIndex: index})
+  changeActiveTab = index => {
+    this.setState({ visibleProblemIndex: index })
   }
 
   activeProblem = () => {
     const problemList = this.props.problemList
-    if ( !Array.isArray(problemList) ) {
+    if (!Array.isArray(problemList)) {
       return {}
     }
     return this.props.problemList[this.state.visibleProblemIndex]
@@ -58,21 +55,17 @@ class TheProblems extends React.Component {
 
   render() {
     const problemList = this.props.problemList
-    if ( !Array.isArray(problemList) ) {
+    if (!Array.isArray(problemList)) {
       return (
-        <div className='problems'>
+        <div className="problems">
           <h1>問題が登録されていません</h1>
         </div>
       )
     }
     return (
-      <div className='problems'>
-        <div className='problem-tabs'>
-          {this.renderTabs(this.state.visibleProblemIndex)}
-        </div>
-        <ProblemContents
-          contents={this.activeProblem()}
-        />
+      <div className="problems">
+        <div className="problem-tabs">{this.renderTabs(this.state.visibleProblemIndex)}</div>
+        <ProblemContents contents={this.activeProblem()} />
       </div>
     )
   }
@@ -81,5 +74,6 @@ class TheProblems extends React.Component {
 export default connect(
   state => ({
     //problems: state.problems.problemList
-  }),{}
+  }),
+  {}
 )(TheProblems)

--- a/app/javascript/components/exercise/TheProblems.js
+++ b/app/javascript/components/exercise/TheProblems.js
@@ -12,9 +12,7 @@ class TheProblems extends React.Component {
   renderTabs = visibleProblemIndex => {
     return (
       <div className="tabs">
-        <ul>
-          {this.props.problemList.map((p, i) => this.renderTab(i, visibleProblemIndex))}
-        </ul>
+        <ul>{this.props.problemList.map((p, i) => this.renderTab(i, visibleProblemIndex))}</ul>
       </div>
     )
   }

--- a/app/javascript/components/exercise/TheProblems.js
+++ b/app/javascript/components/exercise/TheProblems.js
@@ -12,7 +12,9 @@ class TheProblems extends React.Component {
   renderTabs = visibleProblemIndex => {
     return (
       <div className="tabs">
-        {this.props.problemList.map((p, i) => this.renderTab(i, visibleProblemIndex))}
+        <ul>
+          {this.props.problemList.map((p, i) => this.renderTab(i, visibleProblemIndex))}
+        </ul>
       </div>
     )
   }

--- a/app/javascript/components/exercise/TheProblems.js
+++ b/app/javascript/components/exercise/TheProblems.js
@@ -1,0 +1,51 @@
+import React from 'react'
+import { connect } from 'react-redux'
+
+class TheProblems extends React.Component {
+  constructor(props) {
+    super(props)
+    this.state = {
+      visibleProblemIndex: 0
+    }
+  }
+  renderTabs = () => {
+    const problemList = this.props.problemList
+    console.log(problemList)
+    if ( !Array.isArray(problemList) ) {
+      return (<h1>問題が登録されていません</h1>)
+    }
+    return (
+      <div className='tabs'>
+        {
+          problemList.map((p, i) => (
+            this.renderTab(i)
+          ))
+        }
+      </div>
+    )
+  }
+
+  renderTab = (index) => {
+    return (
+      <li className={index === this.state.visibleProblemIndex && 'is-active'} key={index}>
+        <a>{`problem${index+1}`}</a>
+      </li>
+    )
+  }
+
+  render() {
+    return (
+      <div className='problems'>
+        <div className='problem-tabs'>
+          { this.renderTabs() }
+        </div>
+      </div>
+    )
+  }
+}
+
+export default connect(
+  state => ({
+    //problems: state.problems.problemList
+  }),{}
+)(TheProblems)

--- a/app/javascript/components/exercise/TheProblems.js
+++ b/app/javascript/components/exercise/TheProblems.js
@@ -1,5 +1,6 @@
 import React from 'react'
 import { connect } from 'react-redux'
+import ProblemContents from './ProblemContents'
 
 class TheProblems extends React.Component {
   constructor(props) {
@@ -9,15 +10,10 @@ class TheProblems extends React.Component {
     }
   }
   renderTabs = (visibleProblemIndex) => {
-    const problemList = this.props.problemList
-    console.log(problemList)
-    if ( !Array.isArray(problemList) ) {
-      return (<h1>問題が登録されていません</h1>)
-    }
     return (
       <div className='tabs'>
         {
-          problemList.map((p, i) => (
+          this.props.problemList.map((p, i) => (
             this.renderTab(i, visibleProblemIndex)
           ))
         }
@@ -31,7 +27,7 @@ class TheProblems extends React.Component {
         <li
           className={index === visibleProblemIndex && 'is-active'}
           key={index}
-          onClick={ () => { this.changeActiveTab(index) }}
+          onClick={() => {this.changeActiveTab(index)}}
         >
           <a>{`problem${index+1}`}</a>
         </li>
@@ -40,7 +36,7 @@ class TheProblems extends React.Component {
     return (
       <li
         key={index}
-        onClick={ () => { this.changeActiveTab(index) }}
+        onClick={() => {this.changeActiveTab(index)}}
       >
         <a>{`problem${index+1}`}</a>
       </li>
@@ -52,12 +48,31 @@ class TheProblems extends React.Component {
     this.setState({visibleProblemIndex: index})
   }
 
+  activeProblem = () => {
+    const problemList = this.props.problemList
+    if ( !Array.isArray(problemList) ) {
+      return {}
+    }
+    return this.props.problemList[this.state.visibleProblemIndex]
+  }
+
   render() {
+    const problemList = this.props.problemList
+    if ( !Array.isArray(problemList) ) {
+      return (
+        <div className='problems'>
+          <h1>問題が登録されていません</h1>
+        </div>
+      )
+    }
     return (
       <div className='problems'>
         <div className='problem-tabs'>
-          { this.renderTabs(this.state.visibleProblemIndex) }
+          {this.renderTabs(this.state.visibleProblemIndex)}
         </div>
+        <ProblemContents
+          contents={this.activeProblem()}
+        />
       </div>
     )
   }

--- a/app/javascript/components/exercise/TheProblems.js
+++ b/app/javascript/components/exercise/TheProblems.js
@@ -8,7 +8,7 @@ class TheProblems extends React.Component {
       visibleProblemIndex: 0
     }
   }
-  renderTabs = () => {
+  renderTabs = (visibleProblemIndex) => {
     const problemList = this.props.problemList
     console.log(problemList)
     if ( !Array.isArray(problemList) ) {
@@ -18,26 +18,45 @@ class TheProblems extends React.Component {
       <div className='tabs'>
         {
           problemList.map((p, i) => (
-            this.renderTab(i)
+            this.renderTab(i, visibleProblemIndex)
           ))
         }
       </div>
     )
   }
 
-  renderTab = (index) => {
+  renderTab = (index, visibleProblemIndex) => {
+    if ( index === visibleProblemIndex) {
+      return (
+        <li
+          className={index === visibleProblemIndex && 'is-active'}
+          key={index}
+          onClick={ () => { this.changeActiveTab(index) }}
+        >
+          <a>{`problem${index+1}`}</a>
+        </li>
+      )
+    }
     return (
-      <li className={index === this.state.visibleProblemIndex && 'is-active'} key={index}>
+      <li
+        key={index}
+        onClick={ () => { this.changeActiveTab(index) }}
+      >
         <a>{`problem${index+1}`}</a>
       </li>
+
     )
+  }
+
+  changeActiveTab = (index) => {
+    this.setState({visibleProblemIndex: index})
   }
 
   render() {
     return (
       <div className='problems'>
         <div className='problem-tabs'>
-          { this.renderTabs() }
+          { this.renderTabs(this.state.visibleProblemIndex) }
         </div>
       </div>
     )

--- a/app/javascript/components/exercise/index.js
+++ b/app/javascript/components/exercise/index.js
@@ -1,8 +1,12 @@
 import React, { Component } from 'react'
 import { Provider } from 'react-redux'
 
+import TheExercise from './TheExercise'
+
 export default function Exercise(props) {
-  return(
-    <h1>exercise page</h1>
+  return (
+    <div className="container">
+      <TheExercise {...props} />
+    </div>
   )
 }

--- a/app/javascript/components/exercise/index.js
+++ b/app/javascript/components/exercise/index.js
@@ -1,0 +1,8 @@
+import React, { Component } from 'react'
+import { Provider } from 'react-redux'
+
+export default function Exercise(props) {
+  return(
+    <h1>exercise page</h1>
+  )
+}

--- a/app/javascript/components/exercise/index.js
+++ b/app/javascript/components/exercise/index.js
@@ -1,12 +1,17 @@
 import React, { Component } from 'react'
 import { Provider } from 'react-redux'
+import createStore from '../../stores/exercise'
 
 import TheExercise from './TheExercise'
 
+const store = createStore()
+
 export default function Exercise(props) {
   return (
-    <div className="container">
-      <TheExercise {...props} />
-    </div>
+    <Provider store={store}>
+      <div className="container">
+        <TheExercise {...props} />
+      </div>
+    </Provider>
   )
 }

--- a/app/javascript/packs/exercise.js
+++ b/app/javascript/packs/exercise.js
@@ -1,0 +1,9 @@
+import 'babel-polyfill'
+import WebpackerReact from 'webpacker-react'
+import Exercise from '../components/exercise'
+
+window.Turbolinks.start()
+
+WebpackerReact.setup({
+  Exercise
+})

--- a/app/javascript/reducers/exercise/index.js
+++ b/app/javascript/reducers/exercise/index.js
@@ -1,0 +1,6 @@
+import { combineReducers } from 'redux'
+import problems from './problems'
+
+export default combineReducers({
+  problems
+})

--- a/app/javascript/reducers/exercise/initialState.js
+++ b/app/javascript/reducers/exercise/initialState.js
@@ -2,15 +2,19 @@ export const initialState = {
   problems: {
     problemsWithTests: [],
     questionsWithTests: [],
-    problemList: [{
-      id: 0,
-      name: "",
-      detail: "",
-      questionList: [{
+    problemList: [
+      {
         id: 0,
-        name: "",
-        detail: ""
-      }]
-    }]
+        name: '',
+        detail: '',
+        questionList: [
+          {
+            id: 0,
+            name: '',
+            detail: ''
+          }
+        ]
+      }
+    ]
   }
 }

--- a/app/javascript/reducers/exercise/initialState.js
+++ b/app/javascript/reducers/exercise/initialState.js
@@ -1,0 +1,16 @@
+export const initialState = {
+  problems: {
+    problemsWithTests: [],
+    questionsWithTests: [],
+    problemList: [{
+      id: 0,
+      name: "",
+      detail: "",
+      questionList: [{
+        id: 0,
+        name: "",
+        detail: ""
+      }]
+    }]
+  }
+}

--- a/app/javascript/reducers/exercise/initialState.js
+++ b/app/javascript/reducers/exercise/initialState.js
@@ -9,7 +9,9 @@ export const initialState = {
           {
             id: 0,
             name: '',
-            detail: ''
+            detail: '',
+            perfectScore: 0,
+            currentScore: 0
           }
         ]
       }

--- a/app/javascript/reducers/exercise/initialState.js
+++ b/app/javascript/reducers/exercise/initialState.js
@@ -1,7 +1,5 @@
 export const initialState = {
   problems: {
-    problemsWithTests: [],
-    questionsWithTests: [],
     problemList: [
       {
         id: 0,
@@ -15,6 +13,11 @@ export const initialState = {
           }
         ]
       }
-    ]
+    ],
+    meta: {
+      problemsWithTests: [],
+      questionsWithTests: [],
+      javaPiercedContents: []
+    }
   }
 }

--- a/app/javascript/reducers/exercise/problems.js
+++ b/app/javascript/reducers/exercise/problems.js
@@ -3,7 +3,7 @@ import { createReducer } from 'redux-act'
 import { initialState } from './initialState'
 import * as actions from '../../actions/exercise'
 
-const createProblemList = (problemData, questionData) => {
+const createProblemList = (problemData, questionData, score) => {
   return problemData.map(p => ({
     id: p.id,
     name: p.name,
@@ -13,7 +13,9 @@ const createProblemList = (problemData, questionData) => {
       .map(q => ({
         id: q.id,
         name: q.name,
-        detail: q.detail
+        detail: q.detail,
+        perfectScore: score['question'][q.id].perfect,
+        currentScore: score['question'][q.id].current,
       }))
   }))
 }
@@ -21,8 +23,8 @@ const createProblemList = (problemData, questionData) => {
 const problems = createReducer(
   {
     [actions.initializeProblemAndQuestionData]: (state, payload) => {
-      const { problemData, questionData } = payload
-      const problemList = createProblemList(problemData, questionData)
+      const { problemData, questionData, score } = payload
+      const problemList = createProblemList(problemData, questionData, score)
 
       const nextState = immer(state, draft => {
         draft.problemList = problemList

--- a/app/javascript/reducers/exercise/problems.js
+++ b/app/javascript/reducers/exercise/problems.js
@@ -25,9 +25,10 @@ const problems = createReducer(
       const problemList = createProblemList(problemData, questionData)
 
       const nextState = immer(state, draft => {
-        draft.problemsWithTests = payload.problemsWithTests
-        draft.questionsWithTests = payload.questionsWithTests
         draft.problemList = problemList
+        draft.meta.problemsWithTests = payload.problemsWithTests
+        draft.meta.questionsWithTests = payload.questionsWithTests
+        draft.meta.javaPiercedContents = payload.javaPiercedContents
       })
       return nextState
     }

--- a/app/javascript/reducers/exercise/problems.js
+++ b/app/javascript/reducers/exercise/problems.js
@@ -8,7 +8,7 @@ const createProblemList = (problemData, questionData) => {
     id: p.id,
     name: p.name,
     detail: p.detail,
-    questions: questionData
+    questionList: questionData
       .filter(q => q.problem_id === p.id)
       .map(q => ({
         id: q.id,

--- a/app/javascript/reducers/exercise/problems.js
+++ b/app/javascript/reducers/exercise/problems.js
@@ -8,18 +8,19 @@ const createProblemList = (problemData, questionData) => {
     id: p.id,
     name: p.name,
     detail: p.detail,
-    questions: questionData.filter(q => q.problem_id === p.id).map(q => ({
-      id: q.id,
-      name: q.name,
-      detail: q.detail
-    }))
+    questions: questionData
+      .filter(q => q.problem_id === p.id)
+      .map(q => ({
+        id: q.id,
+        name: q.name,
+        detail: q.detail
+      }))
   }))
 }
 
 const problems = createReducer(
   {
     [actions.initializeProblemAndQuestionData]: (state, payload) => {
-      console.log(payload)
       const { problemData, questionData } = payload
       const problemList = createProblemList(problemData, questionData)
 

--- a/app/javascript/reducers/exercise/problems.js
+++ b/app/javascript/reducers/exercise/problems.js
@@ -1,0 +1,37 @@
+import immer from 'immer'
+import { createReducer } from 'redux-act'
+import { initialState } from './initialState'
+import * as actions from '../../actions/exercise'
+
+const createProblemList = (problems, questions) => {
+  return problems.map(p => ({
+    id: p.id,
+    name: p.name,
+    detail: p.detail,
+    questions: questions.filter(q => q.problem_id === p.id).map(q => ({
+      id: q.id,
+      name: q.name,
+      detail: q.detail
+    }))
+  }))
+}
+
+const problems = createReducer(
+  {
+    [actions.initializeProblemAndQuestionData]: (state, payload) => {
+      console.log(payload)
+      const { problems, questions } = payload
+      const problemList = createProblemList(problems, questions)
+
+      const nextState = immer(state, draft => {
+        draft.problemsWithTests = payload.problemsWithTests
+        draft.questionsWithTests = payload.questionsWithTests
+        draft.problemList = problemList
+      })
+      return nextState
+    }
+  },
+  initialState.problems
+)
+
+export default problems

--- a/app/javascript/reducers/exercise/problems.js
+++ b/app/javascript/reducers/exercise/problems.js
@@ -15,7 +15,7 @@ const createProblemList = (problemData, questionData, score) => {
         name: q.name,
         detail: q.detail,
         perfectScore: score['question'][q.id].perfect,
-        currentScore: score['question'][q.id].current,
+        currentScore: score['question'][q.id].current
       }))
   }))
 }

--- a/app/javascript/reducers/exercise/problems.js
+++ b/app/javascript/reducers/exercise/problems.js
@@ -3,12 +3,12 @@ import { createReducer } from 'redux-act'
 import { initialState } from './initialState'
 import * as actions from '../../actions/exercise'
 
-const createProblemList = (problems, questions) => {
-  return problems.map(p => ({
+const createProblemList = (problemData, questionData) => {
+  return problemData.map(p => ({
     id: p.id,
     name: p.name,
     detail: p.detail,
-    questions: questions.filter(q => q.problem_id === p.id).map(q => ({
+    questions: questionData.filter(q => q.problem_id === p.id).map(q => ({
       id: q.id,
       name: q.name,
       detail: q.detail
@@ -20,8 +20,8 @@ const problems = createReducer(
   {
     [actions.initializeProblemAndQuestionData]: (state, payload) => {
       console.log(payload)
-      const { problems, questions } = payload
-      const problemList = createProblemList(problems, questions)
+      const { problemData, questionData } = payload
+      const problemList = createProblemList(problemData, questionData)
 
       const nextState = immer(state, draft => {
         draft.problemsWithTests = payload.problemsWithTests

--- a/app/javascript/stores/exercise/index.js
+++ b/app/javascript/stores/exercise/index.js
@@ -1,0 +1,12 @@
+import { createStore, applyMiddleware, compose } from 'redux'
+import { createLogger } from 'redux-logger'
+import reducer from '../../reducers/exercise'
+
+const logger = createLogger()
+
+export default () => {
+  const middlewares = []
+  middlewares.push(logger)
+  const store = compose(applyMiddleware(...middlewares))(createStore)(reducer)
+  return store
+}

--- a/app/models/mission.rb
+++ b/app/models/mission.rb
@@ -55,11 +55,12 @@ class Mission < ApplicationRecord
 
   def java_problem_contents(user_id)
     submit = Submit.where(user_id: user_id, mission_id: self).last
-    if submit.nil?
-      @java_problem_contents = java_pierced_contents
-    else
-      @java_problem_contents = java_submitted_contents(submit.id)
-    end
+    java_contents = if submit
+                      java_submitted_contents(submit.id)
+                    else
+                      java_pierced_contents
+                    end
+    java_contents
   end
 
   def java_pierced_contents
@@ -72,7 +73,7 @@ class Mission < ApplicationRecord
 
   def java_submitted_contents(submit_id)
     java_contents = java_contents_per_lines
-    pierced_locations.with_submit_codes(submit_id).order('file_name DESC').order('location_id DESC').each do |p|
+    pierced_locations.with_submit_codes(submit_id).each do |p|
       java_contents[p.file_name].slice!(p.lines[0], p.lines.length)
       java_contents[p.file_name].insert(p.lines[0], p.code)
     end

--- a/app/models/mission.rb
+++ b/app/models/mission.rb
@@ -53,6 +53,18 @@ class Mission < ApplicationRecord
     end
   end
 
+  def java_pierced_contents
+    java_contents = java_contents_per_lines
+    pierced_locations.each do |p|
+      java_contents[p.file_name].slice!(p.lines[0], p.lines.length)
+    end
+    java_contents.map { |file, content| { file => content.join("\n") } }
+  end
+
+  def java_contents_per_lines
+    java_main_contents.map { |content| [content.keys[0], content.values[0].split(/\n/)] }.to_h
+  end
+
   private
 
   def files

--- a/app/models/mission.rb
+++ b/app/models/mission.rb
@@ -55,10 +55,10 @@ class Mission < ApplicationRecord
 
   def java_problem_contents(user_id)
     submit = Submit.where(user_id: user_id, mission_id: self).last
-    if submit
-      @java_problem_contents = java_submitted_contents(submit.id)
-    else
+    if submit.nil?
       @java_problem_contents = java_pierced_contents
+    else
+      @java_problem_contents = java_submitted_contents(submit.id)
     end
   end
 

--- a/app/models/mission.rb
+++ b/app/models/mission.rb
@@ -53,6 +53,15 @@ class Mission < ApplicationRecord
     end
   end
 
+  def java_problem_contents(user_id)
+    submit = Submit.where(user_id: user_id, mission_id: self).last
+    if submit
+      @java_problem_contents = java_submitted_contents(submit.id)
+    else
+      @java_problem_contents = java_pierced_contents
+    end
+  end
+
   def java_pierced_contents
     java_contents = java_contents_per_lines
     pierced_locations.order('file_name DESC').order('location_id DESC').each do |p|

--- a/app/models/mission.rb
+++ b/app/models/mission.rb
@@ -61,8 +61,21 @@ class Mission < ApplicationRecord
     java_contents.map { |file, content| { file => content.join("\n") } }
   end
 
+  def java_submited_contents(submit_id)
+    java_contents = java_contents_per_lines
+    pierced_locations.with_submit_codes(submit_id).order('file_name DESC').order('location_id DESC').each do |p|
+      java_contents[p.file_name].slice!(p.lines[0], p.lines.length)
+      java_contents[p.file_name].insert(p.lines[0], p.code)
+    end
+    java_contents.map { |file, content| { file => content.join("\n") } }
+  end
+
   def java_contents_per_lines
     java_main_contents.map { |content| [content.keys[0], content.values[0].split(/\n/)] }.to_h
+  end
+
+  def copy_repo(root_path)
+    FileUtils.cp_r(absolute_path, root_path)
   end
 
   private

--- a/app/models/mission.rb
+++ b/app/models/mission.rb
@@ -61,7 +61,7 @@ class Mission < ApplicationRecord
     java_contents.map { |file, content| { file => content.join("\n") } }
   end
 
-  def java_submited_contents(submit_id)
+  def java_submitted_contents(submit_id)
     java_contents = java_contents_per_lines
     pierced_locations.with_submit_codes(submit_id).order('file_name DESC').order('location_id DESC').each do |p|
       java_contents[p.file_name].slice!(p.lines[0], p.lines.length)
@@ -72,6 +72,26 @@ class Mission < ApplicationRecord
 
   def java_contents_per_lines
     java_main_contents.map { |content| [content.keys[0], content.values[0].split(/\n/)] }.to_h
+  end
+
+  def create_submitted_project(submit_id, root_path)
+    copy_repo(root_path)
+    project_root = root_path + '/' + File.basename(local_repository)
+    java_submitted_contents(submit_id).each do |contents|
+      contents.each do |key, value|
+        File.write(project_root + key, value)
+      end
+    end
+  end
+
+  def create_pierced_project(root_path)
+    copy_repo(root_path)
+    project_root = root_path + '/' + File.basename(local_repository)
+    java_pierced_contents.each do |contents|
+      contents.each do |key, value|
+        File.write(project_root + key, value)
+      end
+    end
   end
 
   def copy_repo(root_path)

--- a/app/models/mission.rb
+++ b/app/models/mission.rb
@@ -82,6 +82,7 @@ class Mission < ApplicationRecord
         File.write(project_root + key, value)
       end
     end
+    project_root
   end
 
   def create_pierced_project(root_path)
@@ -92,6 +93,7 @@ class Mission < ApplicationRecord
         File.write(project_root + key, value)
       end
     end
+    project_root
   end
 
   def copy_repo(root_path)

--- a/app/models/mission.rb
+++ b/app/models/mission.rb
@@ -55,7 +55,7 @@ class Mission < ApplicationRecord
 
   def java_pierced_contents
     java_contents = java_contents_per_lines
-    pierced_locations.each do |p|
+    pierced_locations.order('file_name DESC').order('location_id DESC').each do |p|
       java_contents[p.file_name].slice!(p.lines[0], p.lines.length)
     end
     java_contents.map { |file, content| { file => content.join("\n") } }

--- a/app/models/pierced_location.rb
+++ b/app/models/pierced_location.rb
@@ -15,7 +15,10 @@ class PiercedLocation < ApplicationRecord
   scope :problem_test_info, -> {
     select(
       'pierced_locations.lines,
-      tests.test_name, tests.test_command,
+      pierced_locations.file_name,
+      tests.test_name,
+      tests.test_command,
+      problem_tests.problem_id,
       problem_tests.score,
       problem_tests.pierced_level'
     )
@@ -31,7 +34,9 @@ class PiercedLocation < ApplicationRecord
   scope :question_test_info, -> {
     select(
       'pierced_locations.lines,
-      tests.test_name, tests.test_command,
+      pierced_locations.file_name,
+      tests.test_name,
+      tests.test_command,
       question_tests.score,
       question_tests.pierced_level'
     )

--- a/app/models/pierced_location.rb
+++ b/app/models/pierced_location.rb
@@ -43,4 +43,16 @@ class PiercedLocation < ApplicationRecord
       question_tests.pierced_level'
     )
   }
+
+  scope :with_submit_codes, ->(submit_id) {
+    joins(:submit_codes)
+      .select(
+        'submit_codes.submit_id,
+        submit_codes.file_name,
+        submit_codes.code,
+        pierced_locations.lines,
+        pierced_locations.location_id'
+      )
+      .where(submit_codes: { submit_id: submit_id })
+  }
 end

--- a/app/models/pierced_location.rb
+++ b/app/models/pierced_location.rb
@@ -37,6 +37,7 @@ class PiercedLocation < ApplicationRecord
       pierced_locations.file_name,
       tests.test_name,
       tests.test_command,
+      question_tests.question_id,
       question_tests.score,
       question_tests.pierced_level'
     )

--- a/app/models/pierced_location.rb
+++ b/app/models/pierced_location.rb
@@ -54,5 +54,7 @@ class PiercedLocation < ApplicationRecord
         pierced_locations.location_id'
       )
       .where(submit_codes: { submit_id: submit_id })
+      .order('file_name DESC')
+      .order('location_id DESC')
   }
 end

--- a/app/models/pierced_location.rb
+++ b/app/models/pierced_location.rb
@@ -4,6 +4,7 @@ class PiercedLocation < ApplicationRecord
   serialize :lines
   belongs_to :mission
   has_many :tests
+  has_many :submit_codes
 
   scope :of_problem_with_test_info, ->(problem_id) {
     with_test_and_problem

--- a/app/models/problem.rb
+++ b/app/models/problem.rb
@@ -19,12 +19,18 @@ class Problem < ApplicationRecord
   has_many :tests, through: :problem_tests
 
   scope :of_mission, ->(mission_id) { where(mission_id: mission_id) }
-  scope :search_test_with_problem_id, ->(problem_id) {
+  scope :search_tests_with_problem_id, ->(problem_id) {
     with_tests
       .problem_and_test_info
       .where(problems: {id: problem_id})
   }
-  scope :with_tests, -> { joins(problem_tests: :test) }
+  scope :search_questions_with_problem_id, ->(problem_id) {
+    with_questions
+      .problem_and_question_info
+      .where(problems: { id: problem_id })
+  }
+
+  scope :with_tests, -> { left_joins(problem_tests: :test) }
   scope :problem_and_test_info, -> {
     select(
       'problems.*,
@@ -33,6 +39,17 @@ class Problem < ApplicationRecord
       tests.test_name,
       tests.test_command,
       tests.pierced_location_id'
+    )
+  }
+  scope :with_questions, -> { left_joins(:questions) }
+  scope :problem_and_question_info, -> {
+    select(
+      'problems.id AS problem_id,
+      problems.name AS problem_name,
+      problems.detail AS problem_detail,
+      questions.id AS question_id,
+      questions.name AS question_name,
+      questions.detail AS question_detail'
     )
   }
 

--- a/app/models/problem.rb
+++ b/app/models/problem.rb
@@ -22,14 +22,8 @@ class Problem < ApplicationRecord
   scope :search_tests_with_problem_id, ->(problem_id) {
     with_tests
       .problem_and_test_info
-      .where(problems: {id: problem_id})
-  }
-  scope :search_questions_with_problem_id, ->(problem_id) {
-    with_questions
-      .problem_and_question_info
       .where(problems: { id: problem_id })
   }
-
   scope :with_tests, -> { left_joins(problem_tests: :test) }
   scope :problem_and_test_info, -> {
     select(
@@ -39,17 +33,6 @@ class Problem < ApplicationRecord
       tests.test_name,
       tests.test_command,
       tests.pierced_location_id'
-    )
-  }
-  scope :with_questions, -> { left_joins(:questions) }
-  scope :problem_and_question_info, -> {
-    select(
-      'problems.id AS problem_id,
-      problems.name AS problem_name,
-      problems.detail AS problem_detail,
-      questions.id AS question_id,
-      questions.name AS question_name,
-      questions.detail AS question_detail'
     )
   }
 

--- a/app/models/problem.rb
+++ b/app/models/problem.rb
@@ -19,6 +19,22 @@ class Problem < ApplicationRecord
   has_many :tests, through: :problem_tests
 
   scope :of_mission, ->(mission_id) { where(mission_id: mission_id) }
+  scope :search_test_with_problem_id, ->(problem_id) {
+    with_tests
+      .problem_and_test_info
+      .where(problems: {id: problem_id})
+  }
+  scope :with_tests, -> { joins(problem_tests: :test) }
+  scope :problem_and_test_info, -> {
+    select(
+      'problems.*,
+      problem_tests.score,
+      problem_tests.pierced_level,
+      tests.test_name,
+      tests.test_command,
+      tests.pierced_location_id'
+    )
+  }
 
   def pierced_locations
     mission.pierced_locations

--- a/app/models/question.rb
+++ b/app/models/question.rb
@@ -108,7 +108,6 @@ class Question < ApplicationRecord
     score_info = QuestionTest.where(question_id: question_id)
     score_info.each do |info|
       score[info.question_id] = score[info.question_id].to_i + info.score
-      #score += info.score
     end
     score
   end

--- a/app/models/question.rb
+++ b/app/models/question.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class Question < ApplicationRecord
+class Question < ApplicationRecord # rubocop:disable Metrics/ClassLength
   belongs_to :problem
   has_many :question_tests
   has_many :tests, through: :question_tests

--- a/app/models/question.rb
+++ b/app/models/question.rb
@@ -6,6 +6,23 @@ class Question < ApplicationRecord
   has_many :tests, through: :question_tests
 
   scope :of_problem, ->(problem_id) { where(problem_id: problem_id) }
+  scope :search_tests_with_problem_id, ->(problem_id) {
+    with_tests
+      .question_and_test_info
+      .where(questions: {problem_id: problem_id})
+  }
+
+  scope :with_tests, -> { left_joins(question_tests: :test) }
+  scope :question_and_test_info, -> {
+    select(
+      'questions.*,
+      question_tests.score,
+      question_tests.pierced_level,
+      tests.test_name,
+      tests.test_command,
+      tests.pierced_location_id'
+    )
+  }
 
   def problem
     @problem = Problem.find_by(id: problem_id) if @problem.nil?

--- a/app/models/question.rb
+++ b/app/models/question.rb
@@ -4,6 +4,8 @@ class Question < ApplicationRecord
   belongs_to :problem
   has_many :question_tests
   has_many :tests, through: :question_tests
+  has_one :submit_question
+  has_one :submit, through: :submit_question
 
   scope :of_problem, ->(problem_id) { where(problem_id: problem_id) }
   scope :search_tests_with_problem_id, ->(problem_id) {

--- a/app/models/question.rb
+++ b/app/models/question.rb
@@ -4,8 +4,8 @@ class Question < ApplicationRecord
   belongs_to :problem
   has_many :question_tests
   has_many :tests, through: :question_tests
-  has_one :submit_question
-  has_one :submit, through: :submit_question
+  has_many :submit_questions
+  has_many :submit, through: :submit_questions
 
   scope :of_problem, ->(problem_id) { where(problem_id: problem_id) }
   scope :search_tests_with_problem_id, ->(problem_id) {

--- a/app/models/question.rb
+++ b/app/models/question.rb
@@ -9,7 +9,7 @@ class Question < ApplicationRecord
   scope :search_tests_with_problem_id, ->(problem_id) {
     with_tests
       .question_and_test_info
-      .where(questions: {problem_id: problem_id})
+      .where(questions: { problem_id: problem_id })
   }
 
   scope :with_tests, -> { left_joins(question_tests: :test) }

--- a/app/models/question.rb
+++ b/app/models/question.rb
@@ -91,28 +91,37 @@ class Question < ApplicationRecord
   end
 
   def self.calc_score(user_id, question_id)
+    scores = {}
     perfect_score = calc_perfect_score(question_id)
     current_score = calc_user_score(user_id, question_id)
-    { question_id => { perfect: perfect_score, current: current_score } }
+    perfect_score.each do |id, p|
+      scores[id] = {
+        perfect: p,
+        current: current_score[id].to_i
+      }
+    end
+    scores
   end
 
   def self.calc_perfect_score(question_id)
-    score = 0
+    score = {}
     score_info = QuestionTest.where(question_id: question_id)
     score_info.each do |info|
-      score += info.score
+      score[info.question_id] = score[info.question_id].to_i + info.score
+      #score += info.score
     end
     score
   end
 
   def self.calc_user_score(user_id, question_id)
-    score = 0
+    score = {}
     last_submits = Submit.last_question_submit_ids(user_id, question_id)
     score_info = with_test_and_submit
                  .search_with_submit_id(last_submits.values)
                  .question_score_info
     score_info.each do |info|
-      score += info.score if info.status == 'SUCCESS'
+      question_id = info.id
+      score[question_id] = score[question_id].to_i + info.score if info.status == 'SUCCESS'
     end
     score
   end

--- a/app/models/submit.rb
+++ b/app/models/submit.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class Submit < ApplicationRecord
+  has_one :submit_question
+  has_one :question, through: :submit_question
+  has_hany :submit_code
+end

--- a/app/models/submit.rb
+++ b/app/models/submit.rb
@@ -4,6 +4,7 @@ class Submit < ApplicationRecord
   has_one :submit_question
   has_one :question, through: :submit_question
   has_many :submit_codes
+  has_many :test_results
   belongs_to :user
   belongs_to :mission
 end

--- a/app/models/submit.rb
+++ b/app/models/submit.rb
@@ -3,5 +3,5 @@
 class Submit < ApplicationRecord
   has_one :submit_question
   has_one :question, through: :submit_question
-  has_hany :submit_code
+  has_many :submit_code
 end

--- a/app/models/submit.rb
+++ b/app/models/submit.rb
@@ -3,5 +3,7 @@
 class Submit < ApplicationRecord
   has_one :submit_question
   has_one :question, through: :submit_question
-  has_many :submit_code
+  has_many :submit_codes
+  belongs_to :user
+  belongs_to :mission
 end

--- a/app/models/submit.rb
+++ b/app/models/submit.rb
@@ -7,4 +7,16 @@ class Submit < ApplicationRecord
   has_many :test_results
   belongs_to :user
   belongs_to :mission
+
+  scope :with_result, -> {
+    joins(:submit_question)
+  }
+
+  # {questionのid: 対応する最大のsubmitのid}
+  def self.last_question_submit_ids(user_id, question_id)
+    with_result
+      .group('submit_questions.question_id')
+      .where(user_id: user_id, submit_questions: { question_id: question_id })
+      .maximum(:id)
+  end
 end

--- a/app/models/submit_code.rb
+++ b/app/models/submit_code.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+class SubmitCode < ApplicationRecord
+  belongs_to :submit
+end

--- a/app/models/submit_code.rb
+++ b/app/models/submit_code.rb
@@ -2,4 +2,5 @@
 
 class SubmitCode < ApplicationRecord
   belongs_to :submit
+  belongs_to :pierced_location
 end

--- a/app/models/submit_question.rb
+++ b/app/models/submit_question.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+class SubmitQuestion < ApplicationRecord
+  belongs_to :submit
+  belongs_to :question
+end

--- a/app/models/test.rb
+++ b/app/models/test.rb
@@ -7,6 +7,7 @@ class Test < ApplicationRecord
   has_many :question_tests
   has_many :problems, through: :problem_tests
   has_many :questions, through: :question_tests
+  has_many :test_results
 
   scope :of_mission, ->(mission_id) { where(mission_id: mission_id) }
 

--- a/app/models/test_result.rb
+++ b/app/models/test_result.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+class TestResult < ApplicationRecord
+  belongs_to :submit
+  belongs_to :test
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -30,6 +30,7 @@ class User < ApplicationRecord
          :recoverable, :rememberable, :trackable, :validatable
 
   has_many :students
+  has_many :submits
 
   def over_ta?
     %w[ta admin super].include? role

--- a/app/views/exercises/show.slim
+++ b/app/views/exercises/show.slim
@@ -19,6 +19,7 @@ section.hero.is-info style="margin-bottom: 30px;"
 
       .wrapper
         = react_component('Exercise',
-        problems_and_questions: @problems_and_questions,
+        problems: @problems,
+        questions: @questions,
         problems_with_tests: @problems_with_tests,
         questions_with_tests: @questions_with_tests)

--- a/app/views/exercises/show.slim
+++ b/app/views/exercises/show.slim
@@ -17,22 +17,7 @@ section.hero.is-info style="margin-bottom: 30px;"
         span.fa.fa-exclamation-circle aria-hidden="true"
           | ここからはReactで書いていくけど、一旦データの確認とページのサンプルとして一覧出力
 
-      - @problems_questions.each do |problem, questions|
-        section
-          .article
-            section
-              h2.subtitle.is-s1
-                | #{problem.name}
-              p = problem.detail
-            section
-              table.table.is-striped.question__table
-                - questions.each do |question|
-                  tr
-                    td.question__item--name
-                      = question.name
-                    td.question__item--detail
-                      = question.detail
-
       .wrapper
         = react_component('Exercise',
-        problems_with_tests: @problems_and_tests)
+        problems_with_tests: @problems_with_tests,
+        problems_questions: @problems_and_questions)

--- a/app/views/exercises/show.slim
+++ b/app/views/exercises/show.slim
@@ -21,5 +21,5 @@ section.hero.is-info style="margin-bottom: 30px;"
         = react_component('Exercise',
         problems: @problems,
         questions: @questions,
-        problems_with_tests: @problems_with_tests,
-        questions_with_tests: @questions_with_tests)
+        problemsWithTests: @problems_with_tests,
+        questionsWithTests: @questions_with_tests)

--- a/app/views/exercises/show.slim
+++ b/app/views/exercises/show.slim
@@ -24,3 +24,9 @@ section.hero.is-info style="margin-bottom: 30px;"
         problemsWithTests: @problems_with_tests,
         questionsWithTests: @questions_with_tests,
         javaPiercedContents: @java_pierced_contents)
+
+javascript:
+  (function() {
+    'use strict'
+    window.exerciseActivity()
+  })()

--- a/app/views/exercises/show.slim
+++ b/app/views/exercises/show.slim
@@ -1,0 +1,34 @@
+section.hero.is-warning
+  .hero-body
+    .container
+      h1.title.is-s1
+        | 演習用のページ
+
+section.hero.is-info style="margin-bottom: 30px;"
+  .hero-body
+    .container
+      h1.subtitle.is-s1
+        | 大問ごとに小問の穴抜き箇所を表示する
+
+.container
+  .columns
+    .column.is-12 style="min-height: 909px;"
+      p.help
+        span.fa.fa-exclamation-circle aria-hidden="true"
+          | ここからはReactで書いていくけど、一旦データの確認とページのサンプルとして一覧出力
+
+      - @problems_questions.each do |problem, questions|
+        section
+          .article
+            section
+              h2.subtitle.is-s1
+                | #{problem.name}
+              p = problem.detail
+            section
+              table.table.is-striped.question__table
+                - questions.each do |question|
+                  tr
+                    td.question__item--name
+                      = question.name
+                    td.question__item--detail
+                      = question.detail

--- a/app/views/exercises/show.slim
+++ b/app/views/exercises/show.slim
@@ -22,4 +22,5 @@ section.hero.is-info style="margin-bottom: 30px;"
         problemData: @problems,
         questionData: @questions,
         problemsWithTests: @problems_with_tests,
-        questionsWithTests: @questions_with_tests)
+        questionsWithTests: @questions_with_tests,
+        javaPiercedContents: @java_pierced_contents)

--- a/app/views/exercises/show.slim
+++ b/app/views/exercises/show.slim
@@ -32,3 +32,6 @@ section.hero.is-info style="margin-bottom: 30px;"
                       = question.name
                     td.question__item--detail
                       = question.detail
+
+      .wrapper
+        = react_component('Exercise', {})

--- a/app/views/exercises/show.slim
+++ b/app/views/exercises/show.slim
@@ -34,4 +34,5 @@ section.hero.is-info style="margin-bottom: 30px;"
                       = question.detail
 
       .wrapper
-        = react_component('Exercise', {})
+        = react_component('Exercise',
+        problems_with_tests: @problems_and_tests)

--- a/app/views/exercises/show.slim
+++ b/app/views/exercises/show.slim
@@ -19,7 +19,7 @@ section.hero.is-info style="margin-bottom: 30px;"
 
       .wrapper
         = react_component('Exercise',
-        problems: @problems,
-        questions: @questions,
+        problemData: @problems,
+        questionData: @questions,
         problemsWithTests: @problems_with_tests,
         questionsWithTests: @questions_with_tests)

--- a/app/views/exercises/show.slim
+++ b/app/views/exercises/show.slim
@@ -21,6 +21,7 @@ section.hero.is-info style="margin-bottom: 30px;"
         = react_component('Exercise',
         problemData: @problems,
         questionData: @questions,
+        score: @score,
         problemsWithTests: @problems_with_tests,
         questionsWithTests: @questions_with_tests,
         javaPiercedContents: @java_pierced_contents)

--- a/app/views/exercises/show.slim
+++ b/app/views/exercises/show.slim
@@ -19,5 +19,6 @@ section.hero.is-info style="margin-bottom: 30px;"
 
       .wrapper
         = react_component('Exercise',
+        problems_and_questions: @problems_and_questions,
         problems_with_tests: @problems_with_tests,
-        problems_questions: @problems_and_questions)
+        questions_with_tests: @questions_with_tests)

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -18,6 +18,7 @@ html lang="ja"
     = javascript_pack_tag 'exercise'
 
   body
+    = render 'layouts/preloader'
     header
       = render 'layouts/navbar'
     main.oodex-main__container

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -15,6 +15,7 @@ html lang="ja"
       media: 'all', \
       'data-turbolinks-track': 'reload')
     = javascript_include_tag 'application', 'data-turbolinks-track': 'reload'
+    = javascript_pack_tag 'exercise'
 
   body
     header

--- a/app/views/sessions/show.slim
+++ b/app/views/sessions/show.slim
@@ -33,7 +33,7 @@ section.hero.is-info style="margin-bottom: 30px;"
           .article
             section
               h2.subtitle.is-s1
-                | #{link_to mission.name, session_exercises_url(@session.id, mission.id)}
+                | #{link_to mission.name, exercises_url(@session.id, mission.id)}
               p = mission.detail
             section
               table.table.is-striped.problem__table

--- a/app/views/sessions/show.slim
+++ b/app/views/sessions/show.slim
@@ -33,11 +33,11 @@ section.hero.is-info style="margin-bottom: 30px;"
           .article
             section
               h2.subtitle.is-s1
-                | #{mission.name}
+                | #{link_to mission.name, session_exercises_url(@session.id, mission.id)}
               p = mission.detail
             section
               table.table.is-striped.problem__table
                 - problems.each do |problem|
                   tr
-                    td.mission__item--name
-                      = link_to problem.name, session_exercises_url(session_id: @session.id, mission_id: mission.id)
+                    td.problem__item--name
+                      = problem.name

--- a/app/views/sessions/show.slim
+++ b/app/views/sessions/show.slim
@@ -1,0 +1,43 @@
+sass:
+  .is-right
+    justify-content: flex-end !important
+
+section.hero.is-warning
+  .hero-body
+    .container
+      p 授業名
+      h1.title.is-s1
+        | #{@session.name}
+
+section.hero.is-info style="margin-bottom: 30px;"
+  .hero-body
+    .container
+      h1.subtitle.is-s1
+        | 授業の説明文
+      p = @session.detail
+
+.container
+  .columns
+    .column.is-12 style="min-height: 909px;"
+
+      - if @missions_problems.size.zero?
+        h1.subtitle.is-s1
+          | まだ課題が登録されていません
+      - else
+        p.help
+          span.fa.fa-exclamation-circle aria-hidden="true"
+            | 課題の名前をクリックすることで、それぞれも課題にアクセスできます。
+
+      - @missions_problems.each do |mission, problems|
+        section
+          .article
+            section
+              h2.subtitle.is-s1
+                | #{mission.name}
+              p = mission.detail
+            section
+              table.table.is-striped.problem__table
+                - problems.each do |problem|
+                  tr
+                    td.mission__item--name
+                      = link_to problem.name, session_exercises_url(session_id: @session.id, mission_id: mission.id)

--- a/app/views/top/index.slim
+++ b/app/views/top/index.slim
@@ -30,7 +30,8 @@ section.hero.is-dark
           tbody
             - @sessions.each do |s|
               tr
-                td.admin-sessions__item--name     = s.name
+                td.admin-sessions__item--name
+                  = link_to s.name, session_url(s.id)
                 td.admin-sessions__item--detail   = s.detail
                 td.admin-sessions__item--start_at = s.start_at
                 td.admin-sessions__item--end_at   = s.end_at

--- a/app/views/top/index.slim
+++ b/app/views/top/index.slim
@@ -31,7 +31,7 @@ section.hero.is-dark
             - @sessions.each do |s|
               tr
                 td.admin-sessions__item--name
-                  = link_to s.name, session_url(s.id)
+                  = link_to s.name, session_show_url(s.id)
                 td.admin-sessions__item--detail   = s.detail
                 td.admin-sessions__item--start_at = s.start_at
                 td.admin-sessions__item--end_at   = s.end_at

--- a/app/workers/question_test_worker.rb
+++ b/app/workers/question_test_worker.rb
@@ -12,7 +12,7 @@ class QuestionTestWorker
     tmpdir = Dir.mktmpdir
     project_root = @mission.create_submitted_project(submit_id, tmpdir)
     Dir.chdir(project_root) do
-      err, status = build('.')
+      status = build('.')
       ExerciseActivityChannel.broadcast_to current_user(submit_id), status: 'fail' if status != 0
       result = Question.find(question_id).tests.map do |test|
         Open3.capture3(test.test_command)
@@ -23,8 +23,8 @@ class QuestionTestWorker
   end
 
   def build(project_root)
-    _, err, status = Open3.capture3("#{project_root}/gradlew clean build")
-    return err, status
+    _, _, status = Open3.capture3("#{project_root}/gradlew clean build")
+    status
   end
 
   def current_user(submit_id)

--- a/app/workers/question_test_worker.rb
+++ b/app/workers/question_test_worker.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require 'open3'
+
+class QuestionTestWorker
+  include Sidekiq::Worker
+
+  sidekiq_options queue: :test, retry: 1
+
+  def perform(submit_id, mission_id, question_id)
+    @mission = Mission.find(mission_id)
+    tmpdir = Dir.mktmpdir
+    project_root = @mission.create_submitted_project(submit_id, tmpdir)
+    Dir.chdir(project_root) do
+      err, status = build('.')
+      puts "コンパイルエラーです\n\n\n#{err.inspect}\n\n\n" if status != 0
+      result = Question.find(question_id).tests.map do |test|
+        Open3.capture3(test.test_command)
+      end
+      puts result
+    end
+  end
+
+  def build(project_root)
+    _, err, status = Open3.capture3("#{project_root}/gradlew clean build")
+    return err, status
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,9 +14,15 @@ Rails.application.routes.draw do
   mount Sidekiq::Web => '/sidekiq' if Rails.env == 'development'
   mount ActionCable.server => '/cable'
 
-  resources :sessions, only: [:show] do
-    get '/missions/:mission_id/exercises', to: 'exercises#show', as: :exercises
-  end
+  # resources :sessions, only: [:show] do
+  #   get '/missions/:mission_id/exercises', to: 'exercises#show', as: :exercises
+  # end
+
+  # sessionという名前をルーティングヘルパーで使うと
+  # deviseのsessionとぶつかって、ログイン時にpostされるURLが変わってしまうようです。
+
+  get '/sessions/:id', to: 'sessions#show', as: :session_show
+  get '/sessions/:session_id/missions/:mission_id/exercises', to: 'exercises#show', as: :exercises
 
   namespace :admin do
     authenticate :user, lambda { |u| u.super? } do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,6 +14,10 @@ Rails.application.routes.draw do
   mount Sidekiq::Web => '/sidekiq' if Rails.env == 'development'
   mount ActionCable.server => '/cable'
 
+  resources :sessions, only: [:show] do
+    get '/missions/:mission_id/exercises', to: 'exercises#show', as: :exercises
+  end
+
   namespace :admin do
     authenticate :user, lambda { |u| u.super? } do
       mount Sidekiq::Web => '/sidekiq'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,6 +9,8 @@ Rails.application.routes.draw do
   namespace :api, defaults: { format: :json } do
     post '/users/sign_in', to: 'users#sign_in'
     delete '/users/sign_out', to: 'users#sign_out'
+
+    post '/submissions/question', to: 'submissions#question'
   end
 
   mount Sidekiq::Web => '/sidekiq' if Rails.env == 'development'

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -6,5 +6,6 @@
 :queues:
   - default
   - event
+  - test
 production:
   :concurrency: 30

--- a/db/migrate/20191225075724_create_submits.rb
+++ b/db/migrate/20191225075724_create_submits.rb
@@ -1,0 +1,10 @@
+class CreateSubmits < ActiveRecord::Migration[5.1]
+  def change
+    create_table :submits do |t|
+      t.integer :user_id, null: false
+      t.integer :mission_id, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20191225080725_create_submit_questions.rb
+++ b/db/migrate/20191225080725_create_submit_questions.rb
@@ -1,0 +1,10 @@
+class CreateSubmitQuestions < ActiveRecord::Migration[5.1]
+  def change
+    create_table :submit_questions do |t|
+      t.integer :submit_id, null: false
+      t.integer :question_id, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20191225080955_create_submit_codes.rb
+++ b/db/migrate/20191225080955_create_submit_codes.rb
@@ -1,0 +1,12 @@
+class CreateSubmitCodes < ActiveRecord::Migration[5.1]
+  def change
+    create_table :submit_codes do |t|
+      t.integer :submit_id, null: false
+      t.string :file_name, null: false
+      t.text :code, null: false
+      t.integer :pierced_location_id, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20200101043754_create_test_results.rb
+++ b/db/migrate/20200101043754_create_test_results.rb
@@ -1,0 +1,13 @@
+class CreateTestResults < ActiveRecord::Migration[5.1]
+  def change
+    create_table :test_results do |t|
+      t.integer :submit_id, null: false
+      t.integer :test_id, null: false
+      t.string :status, null: false
+      t.string :target, null: false
+      t.text :message, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20191022052609) do
+ActiveRecord::Schema.define(version: 20191225080955) do
 
   create_table "missions", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.integer "session_id", null: false
@@ -90,6 +90,29 @@ ActiveRecord::Schema.define(version: 20191022052609) do
     t.integer "user_id", null: false
     t.integer "team_id", null: false
     t.integer "session_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  create_table "submit_codes", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
+    t.integer "submit_id", null: false
+    t.string "file_name", null: false
+    t.text "code", null: false
+    t.integer "pierced_location_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  create_table "submit_questions", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
+    t.integer "submit_id", null: false
+    t.integer "question_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  create_table "submits", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
+    t.integer "user_id", null: false
+    t.integer "mission_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20191225080955) do
+ActiveRecord::Schema.define(version: 20200101043754) do
 
   create_table "missions", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.integer "session_id", null: false
@@ -113,6 +113,16 @@ ActiveRecord::Schema.define(version: 20191225080955) do
   create_table "submits", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.integer "user_id", null: false
     t.integer "mission_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  create_table "test_results", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
+    t.integer "submit_id", null: false
+    t.integer "test_id", null: false
+    t.string "status", null: false
+    t.string "target", null: false
+    t.text "message", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   "dependencies": {
     "@rails/webpacker": "^3.0.1",
     "ace-builds": "^1.4.7",
+    "axios": "^0.19.0",
     "babel-polyfill": "^6.26.0",
     "babel-preset-react": "^6.24.1",
     "bulma": "^0.6.0",

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   },
   "dependencies": {
     "@rails/webpacker": "^3.0.1",
+    "ace-builds": "^1.4.7",
     "babel-polyfill": "^6.26.0",
     "babel-preset-react": "^6.24.1",
     "bulma": "^0.6.0",
@@ -19,6 +20,7 @@
     "prop-types": "^15.6.0",
     "puma": "^4.0.0",
     "react": "^16.0.0",
+    "react-ace": "^8.0.0",
     "react-autobind": "^1.0.6",
     "react-dom": "^16.0.0",
     "react-redux": "^5.0.6",

--- a/spec/controllers/api/submissions_controller_spec.rb
+++ b/spec/controllers/api/submissions_controller_spec.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Api::SubmissionsController, type: :controller do
+end

--- a/spec/controllers/exercises_controller_spec.rb
+++ b/spec/controllers/exercises_controller_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe ExercisesController, type: :controller do
+
+end

--- a/spec/controllers/exercises_controller_spec.rb
+++ b/spec/controllers/exercises_controller_spec.rb
@@ -1,5 +1,6 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe ExercisesController, type: :controller do
-
 end

--- a/spec/controllers/sessions_controller_spec.rb
+++ b/spec/controllers/sessions_controller_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe SessionsController, type: :controller do
+
+end

--- a/spec/controllers/sessions_controller_spec.rb
+++ b/spec/controllers/sessions_controller_spec.rb
@@ -1,5 +1,6 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe SessionsController, type: :controller do
-
 end

--- a/spec/factories/submit_codes.rb
+++ b/spec/factories/submit_codes.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+FactoryGirl.define do
+  factory :submit_code do
+    submit_id 1
+    file_name 'MyString'
+    code 'MyText'
+    pierced_location_id 1
+  end
+end

--- a/spec/factories/submit_questions.rb
+++ b/spec/factories/submit_questions.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+FactoryGirl.define do
+  factory :submit_question do
+    submit_id 1
+    question_id 1
+  end
+end

--- a/spec/factories/submits.rb
+++ b/spec/factories/submits.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+FactoryGirl.define do
+  factory :submit do
+    user_id 1
+    mission_id 1
+  end
+end

--- a/spec/factories/test_results.rb
+++ b/spec/factories/test_results.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+FactoryGirl.define do
+  factory :test_result do
+    submit_id 1
+    test_id 1
+    status 'MyString'
+    target 'MyString'
+    message 'MyText'
+  end
+end

--- a/spec/models/submit_code_spec.rb
+++ b/spec/models/submit_code_spec.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe SubmitCode, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/submit_question_spec.rb
+++ b/spec/models/submit_question_spec.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe SubmitQuestion, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/submit_spec.rb
+++ b/spec/models/submit_spec.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Submit, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/test_result_spec.rb
+++ b/spec/models/test_result_spec.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe TestResult, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/workers/question_test_worker_spec.rb
+++ b/spec/workers/question_test_worker_spec.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+RSpec.describe QuestionTestWorker, type: :worker do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/yarn.lock
+++ b/yarn.lock
@@ -146,6 +146,11 @@ accepts@~1.3.4:
     mime-types "~2.1.16"
     negotiator "0.6.1"
 
+ace-builds@^1.4.6, ace-builds@^1.4.7:
+  version "1.4.7"
+  resolved "https://registry.yarnpkg.com/ace-builds/-/ace-builds-1.4.7.tgz#56e5465270b6c48a48d30e70d6b8f6b92fbf2b08"
+  integrity sha512-gwQGVFewBopRLho08BfahyvRa9FlB43JUig5ItAKTYc9kJJsbA9QNz75p28QtQomoPQ9rJx82ymL21x4ZSZmdg==
+
 acorn-dynamic-import@^2.0.0:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/acorn-dynamic-import/-/acorn-dynamic-import-2.0.2.tgz#c752bd210bef679501b6c6cb7fc84f8f47158cc4"
@@ -2100,6 +2105,11 @@ detect-node@^2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/detect-node/-/detect-node-2.0.3.tgz#a2033c09cc8e158d37748fbde7507832bd6ce127"
 
+diff-match-patch@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/diff-match-patch/-/diff-match-patch-1.0.4.tgz#6ac4b55237463761c4daf0dc603eb869124744b1"
+  integrity sha512-Uv3SW8bmH9nAtHKaKSanOQmj2DnlH65fUpcrMdfdaOxUG02QQ4YGZ8AE7kKOMisF7UqvOlGKVYWRvezdncW9lg==
+
 diffie-hellman@^5.0.0:
   version "5.0.2"
   resolved "https://registry.yarnpkg.com/diffie-hellman/-/diffie-hellman-5.0.2.tgz#b5835739270cfe26acf632099fded2a07f209e5e"
@@ -3879,6 +3889,11 @@ lodash.defaults@^4.0.0, lodash.defaults@^4.2.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/lodash.defaults/-/lodash.defaults-4.2.0.tgz#d09178716ffea4dde9e5fb7b37f6f0802274580c"
 
+lodash.get@^4.4.2:
+  version "4.4.2"
+  resolved "https://registry.yarnpkg.com/lodash.get/-/lodash.get-4.4.2.tgz#2d177f652fa31e939b4438d5341499dfa3825e99"
+  integrity sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=
+
 lodash.isarguments@^3.0.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz#2f573d85c6a24289ff00663b491c1d338ff3458a"
@@ -3886,6 +3901,11 @@ lodash.isarguments@^3.0.0:
 lodash.isarray@^3.0.0:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/lodash.isarray/-/lodash.isarray-3.0.4.tgz#79e4eb88c36a8122af86f844aa9bcd851b5fbb55"
+
+lodash.isequal@^4.5.0:
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/lodash.isequal/-/lodash.isequal-4.5.0.tgz#415c4478f2bcc30120c22ce10ed3226f7d3e18e0"
+  integrity sha1-QVxEePK8wwEgwizhDtMib30+GOA=
 
 lodash.keys@^3.0.0:
   version "3.1.2"
@@ -5525,6 +5545,17 @@ rc@^1.1.7:
     ini "~1.3.0"
     minimist "^1.2.0"
     strip-json-comments "~2.0.1"
+
+react-ace@^8.0.0:
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/react-ace/-/react-ace-8.0.0.tgz#e6fc155ec3cf240e92bdf2e156a50458a78ed0a4"
+  integrity sha512-EvU14vXbZpAenb1ZVKdn8yTQs/shZ9RghFulHtt67bBXT6sjrNHcfOEXHYtSEmwMb6pQVVNNuulzzd8o+Uouig==
+  dependencies:
+    ace-builds "^1.4.6"
+    diff-match-patch "^1.0.4"
+    lodash.get "^4.4.2"
+    lodash.isequal "^4.5.0"
+    prop-types "^15.7.2"
 
 react-autobind@^1.0.6:
   version "1.0.6"

--- a/yarn.lock
+++ b/yarn.lock
@@ -475,6 +475,14 @@ aws4@^1.2.1, aws4@^1.6.0:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.6.0.tgz#83ef5ca860b2b32e4a0deedee8c771b9db57471e"
 
+axios@^0.19.0:
+  version "0.19.0"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-0.19.0.tgz#8e09bff3d9122e133f7b8101c8fbdd00ed3d2ab8"
+  integrity sha512-1uvKqKQta3KBxIz14F2v06AEHZ/dIoeKfbTRkK1E5oqjDnuEerLmYTgJB5AiQZHJcljpg1TuRzdjDR06qNk0DQ==
+  dependencies:
+    follow-redirects "1.5.10"
+    is-buffer "^2.0.2"
+
 babel-code-frame@^6.11.0, babel-code-frame@^6.22.0, babel-code-frame@^6.26.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-code-frame/-/babel-code-frame-6.26.0.tgz#63fd43f7dc1e3bb7ce35947db8fe369a3f58c74b"
@@ -2014,6 +2022,13 @@ debug@2.6.9, debug@^2.2.0, debug@^2.6.6, debug@^2.6.8:
   dependencies:
     ms "2.0.0"
 
+debug@=3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-3.1.0.tgz#5bb5a0672628b64149566ba16819e61518c67261"
+  integrity sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==
+  dependencies:
+    ms "2.0.0"
+
 debug@^3.1.0:
   version "3.2.6"
   resolved "https://registry.yarnpkg.com/debug/-/debug-3.2.6.tgz#e83d17de16d8a7efb7717edbe5fb10135eee629b"
@@ -2751,6 +2766,13 @@ flatten@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/flatten/-/flatten-1.0.2.tgz#dae46a9d78fbe25292258cc1e780a41d95c03782"
 
+follow-redirects@1.5.10:
+  version "1.5.10"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.5.10.tgz#7b7a9f9aea2fdff36786a94ff643ed07f4ff5e2a"
+  integrity sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==
+  dependencies:
+    debug "=3.1.0"
+
 for-in@^0.1.3:
   version "0.1.8"
   resolved "https://registry.yarnpkg.com/for-in/-/for-in-0.1.8.tgz#d8773908e31256109952b1fdb9b3fa867d2775e1"
@@ -3384,6 +3406,11 @@ is-binary-path@^1.0.0:
 is-buffer@^1.0.2, is-buffer@^1.1.5:
   version "1.1.5"
   resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-1.1.5.tgz#1f3b26ef613b214b88cbca23cc6c01d87961eecc"
+
+is-buffer@^2.0.2:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-2.0.4.tgz#3e572f23c8411a5cfd9557c849e3665e0b290623"
+  integrity sha512-Kq1rokWXOPXWuaMAqZiJW4XxsmD9zGx9q4aePabbn3qCRGedtH7Cm+zV8WETitMfu1wdh+Rvd6w5egwSngUX2A==
 
 is-builtin-module@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
問題の登録までは終わっているので、それを表示して学生に出題するページの作成を行う
このページは各設問(mission)ごとに1ページにしたい
大問や小問間での移動のたびにリクエスト飛ばして移動するのは、受ける側が大変そう
なので、ちょっとSPAっぽい感じにしたい(ReactとRedux頑張る)
大問はタブのようなものを用意して切り替えるようにする
そのページに該当の小問全体を表示する方針(1ページが大きくなりそうだったらUIを検討する)

未
- ~穴抜き箇所に入力フォームを配置~

済
- 課題を表示
- ページの作成
- ルーティング
- コードを穴抜き状態で表示
- 穴抜き箇所をパースしてデータを送信