### PR TITLE
各ファイルの穴抜き箇所のlocation idが上から振られるように修正

### DIFF
--- a/app/controllers/admin/missions_controller.rb
+++ b/app/controllers/admin/missions_controller.rb
@@ -47,7 +47,11 @@ class Admin::MissionsController < Admin::ApplicationController
       next unless value.respond_to?(:map)
       value.map(&:to_i)
     end
-    Hash[keys.zip(values)]
+    Hash[keys.zip(sort_serialized_arrays(values))]
+  end
+
+  def sort_serialized_arrays(arrays)
+    arrays.sort_by { |a| a[0] }
   end
 
   def set_mission


### PR DESCRIPTION
現状の実装では、穴抜き箇所のタグ`// ![x 〜 //!]`の`x`部分の数字をパースできていないので、一緒に渡されるkeyをそのままlocation idとして登録していた。
しかし、keyの値は、登録時の 穴抜きにする ボタンの押した順番に振られていたため、押した順次第で値が変わってしまっていた

そこでbackend側で行数のデータからソートして、keyの値と紐付けし直した