### PR TITLE
テストを登録しない選択肢を追加

### DIFF
--- a/app/javascript/components/admin/problem/ThePircedLocationStateEditor.js
+++ b/app/javascript/components/admin/problem/ThePircedLocationStateEditor.js
@@ -50,7 +50,7 @@ export default function ThePircedLocationStateEditor({ problem, testList }) {
               <label className="label is-small">対応テスト</label>
               <div className="select">
                 <select name="tests[]">
-                  {testList.map(key => (
+                  {['この問題では使用しない'].concat(testList).map(key => (
                     <option key={key}>{key}</option>
                   ))}
                 </select>

--- a/app/javascript/components/exercise/ProblemContents.js
+++ b/app/javascript/components/exercise/ProblemContents.js
@@ -10,6 +10,16 @@ const Problem = styled.div`
 `
 
 export default function ProblemContents({ contents }) {
+  if (!contents) {
+    return (
+      <Problem>
+        <h1>大問の登録がありません</h1>
+        <div style={{ margin: '20px', whiteSpace: 'pre-line' }}>
+          <p>大問の登録がないようです。担当教員に確認してください。</p>
+        </div>
+      </Problem>
+    )
+  }
   return (
     <Problem>
       <h1>大問 {contents.name}</h1>

--- a/app/javascript/components/exercise/TheExercise.js
+++ b/app/javascript/components/exercise/TheExercise.js
@@ -26,7 +26,6 @@ class TheExercise extends React.Component {
   render() {
     return (
       <div>
-        <h1>The Exersice</h1>
         <TheProblems problemList={this.props.problems.problemList} />
       </div>
     )

--- a/app/models/problem.rb
+++ b/app/models/problem.rb
@@ -50,6 +50,7 @@ class Problem < ApplicationRecord
     result = { test_list: [], error: nil }
 
     test_names&.each_with_index do |test_name, i|
+      next if test_name == 'この問題では使用しない'
       @test = new_test(test_name, labels[i], pirced_location_ids[i])
       test = @test.save
       test ? result[:test_list] << test : result[:error] = @test.report_errors && break

--- a/app/models/problem.rb
+++ b/app/models/problem.rb
@@ -51,6 +51,7 @@ class Problem < ApplicationRecord
 
     test_names&.each_with_index do |test_name, i|
       next if test_name == 'この問題では使用しない'
+
       @test = new_test(test_name, labels[i], pirced_location_ids[i])
       test = @test.save
       test ? result[:test_list] << test : result[:error] = @test.report_errors && break

--- a/app/models/question.rb
+++ b/app/models/question.rb
@@ -60,6 +60,7 @@ class Question < ApplicationRecord # rubocop:disable Metrics/ClassLength
 
     test_names&.each_with_index do |test_name, i|
       next if test_name == 'この問題では使用しない'
+
       @test = new_test(test_name, labels[i], pirced_location_ids[i])
       test = @test.save
       test ? result[:test_list] << test : result[:error] = @test.report_errors && break

--- a/app/models/question.rb
+++ b/app/models/question.rb
@@ -59,6 +59,7 @@ class Question < ApplicationRecord # rubocop:disable Metrics/ClassLength
     result = { test_list: [], error: nil }
 
     test_names&.each_with_index do |test_name, i|
+      next if test_name == 'この問題では使用しない'
       @test = new_test(test_name, labels[i], pirced_location_ids[i])
       test = @test.save
       test ? result[:test_list] << test : result[:error] = @test.report_errors && break

--- a/app/views/admin/questions/show.slim
+++ b/app/views/admin/questions/show.slim
@@ -3,6 +3,12 @@ section.hero.is-warning
     .container
       h1.subtitle.is-s1
         | #{@question.name}
+      .columns
+        .column.is-offset-10.is-1
+          = link_to '大問に戻る',
+          admin_session_mission_problem_url(@session, @mission, @problem),
+            class: 'button is-link'
+
 
 section.hero.is-info style="margin-bottom: 30px;"
   .hero-body

--- a/app/views/admin/questions/show.slim
+++ b/app/views/admin/questions/show.slim
@@ -9,7 +9,6 @@ section.hero.is-warning
           admin_session_mission_problem_url(@session, @mission, @problem),
             class: 'button is-link'
 
-
 section.hero.is-info style="margin-bottom: 30px;"
   .hero-body
     .container


### PR DESCRIPTION
これまでは、大問や小問の登録の際に、全ての穴抜き箇所を表示しており、登録しないという選択肢がなかったため、全ての問題に全ての穴抜き箇所が登録されてしまっていた。
そのため、登録しない選択肢を追加し、その場合登録をスキップするようにした。

ただし、穴抜きしたプログラムを作成する際に、L0やL1などを考慮していない関係もあり、
登録していないテスト(穴抜き箇所)についても穴を抜いた状態で生成されてしまう。
そのため、テストを登録するプログラムのファイル内で、穴抜き箇所として
登録してしまっている箇所に関しては、全て出題部分とし、テストを登録する必要がある。
(要は、小問はファイル単位での出題になってしまっている)

これについては、別のPRで今後修正予定である。